### PR TITLE
커스텀 홈 모달 시트 구현

### DIFF
--- a/PeepIt/PeepIt/Features/Home/HomeStore.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeStore.swift
@@ -10,14 +10,19 @@ import ComposableArchitecture
 
 @Reducer
 struct HomeStore {
-    
+
+    @ObservableState
     struct State: Equatable {
         var sheetHeight: CGFloat = SheetType.scrollDown.height
         var isScrolledDown: Bool = false
+        var offset: CGFloat = 0
+        var lastOffset: CGFloat = 0
     }
 
     enum Action {
         case setSheetHeight(height: CGFloat)
+        case dragChanged(translationHeight: CGFloat)
+        case drageEnded
         case previewPeepTapped
     }
 
@@ -29,8 +34,25 @@ struct HomeStore {
                 state.isScrolledDown = (height == SheetType.scrollDown.height)
                 return .none
 
+            case let .dragChanged(translationHeight):
+                state.offset = max(
+                    translationHeight,
+                    -(SheetType.scrollUp.height - SheetType.scrollDown.height)
+                ) + state.lastOffset
+
+                return .send(.setSheetHeight(height: -state.offset + SheetType.scrollDown.height))
+
+            case .drageEnded:
+                if -state.offset > SheetType.scrollUp.height / 2 {
+                    state.offset = -(SheetType.scrollUp.height - SheetType.scrollDown.height)
+                } else {
+                    state.offset = 0
+                }
+                
+                state.lastOffset = state.offset
+                return .send(.setSheetHeight(height: -state.offset + SheetType.scrollDown.height))
+
             case .previewPeepTapped:
-                // TODO: 상세 핍 이동
                 print("tap: preview peep")
                 return .none
             }

--- a/PeepIt/PeepIt/Features/Home/HomeStore.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeStore.swift
@@ -17,6 +17,9 @@ struct HomeStore {
         var isScrolledDown: Bool = false
         var offset: CGFloat = 0
         var lastOffset: CGFloat = 0
+        var isPeepDetailShowed: Bool = false
+
+        var peepDetail = PeepDetailStore.State()
     }
 
     enum Action {
@@ -24,9 +27,14 @@ struct HomeStore {
         case dragChanged(translationHeight: CGFloat)
         case drageEnded
         case previewPeepTapped
+        case peepDetail(PeepDetailStore.Action)
     }
 
     var body: some Reducer<State, Action> {
+        Scope(state: \.peepDetail, action: \.peepDetail) {
+            PeepDetailStore()
+        }
+        
         Reduce { state, action in
             switch action {
             case let .setSheetHeight(height):
@@ -53,7 +61,14 @@ struct HomeStore {
                 return .send(.setSheetHeight(height: -state.offset + SheetType.scrollDown.height))
 
             case .previewPeepTapped:
-                print("tap: preview peep")
+                state.isPeepDetailShowed = true
+                return .none
+
+            case .peepDetail(.closeView):
+                state.isPeepDetailShowed = false
+                return .none
+
+            default:
                 return .none
             }
         }

--- a/PeepIt/PeepIt/Features/Home/HomeView.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeView.swift
@@ -58,6 +58,12 @@ struct HomeView: View {
 
                 peepPreviewView
 
+                if store.isPeepDetailShowed {
+                    PeepDetailView(
+                        store: store.scope(state: \.peepDetail, action: \.peepDetail)
+                    )
+                }
+
             }
             .ignoresSafeArea(.all, edges: .bottom)
         }
@@ -71,7 +77,7 @@ extension HomeView {
 
         } label: {
             Rectangle()
-                .frame(width: 30, height: 30)
+                .frame(width: 39, height: 39)
                 .foregroundStyle(Color.gray)
         }
     }
@@ -91,7 +97,7 @@ extension HomeView {
 
         } label: {
             Rectangle()
-                .frame(width: 30, height: 30)
+                .frame(width: 39, height: 39)
                 .foregroundStyle(Color.gray)
         }
     }
@@ -101,7 +107,7 @@ extension HomeView {
 
         } label: {
             Rectangle()
-                .frame(width: 30, height: 30)
+                .frame(width: 39, height: 39)
                 .foregroundStyle(Color.gray)
         }
     }
@@ -111,7 +117,7 @@ extension HomeView {
 
         } label: {
             Rectangle()
-                .frame(width: 30, height: 30)
+                .frame(width: 39, height: 39)
                 .foregroundStyle(Color.gray)
         }
     }

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
@@ -20,10 +20,15 @@ struct PeepDetailStore {
     enum Action {
         case setShowingReactionState(Bool)
         case setShowChat(Bool)
+        case closeView
         case chat(ChatStore.Action)
     }
 
     var body: some Reducer<State, Action> {
+        Scope(state: \.chat, action: \.chat) {
+            ChatStore()
+        }
+        
         Reduce { state, action in
             switch action {
             case let .setShowingReactionState(newState):
@@ -34,8 +39,11 @@ struct PeepDetailStore {
                 state.showChat = newState
                 return .none
 
-            case let .chat(.closeChatButtonTapped):
+            case .chat(.closeChatButtonTapped):
                 state.showChat = false
+                return .none
+
+            case .closeView:
                 return .none
             }
         }

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -15,6 +15,7 @@ struct PeepDetailView: View {
         WithPerceptionTracking {
             ZStack {
                 Color.white
+                    .ignoresSafeArea()
 
                 VStack {
                     HStack {
@@ -52,12 +53,14 @@ struct PeepDetailView: View {
                     }
                     .padding(.leading, 29)
                     .padding(.trailing, 20)
+                    .padding(.bottom, 40)
                 }
 
                 if store.state.showChat {
                     ChatView(store: store.scope(state: \.chat, action: \.chat))
                 }
             }
+            .ignoresSafeArea(.all, edges: .bottom)
         }
     }
 }
@@ -66,7 +69,7 @@ extension PeepDetailView {
 
     private var backButton: some View {
         Button {
-
+            store.send(.closeView)
         } label: {
             Rectangle()
                 .frame(width: 39, height: 39)

--- a/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewModalView.swift
+++ b/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewModalView.swift
@@ -12,12 +12,12 @@ struct PeepPreviewModalView: View {
     let store: StoreOf<HomeStore>
 
     var body: some View {
-        WithViewStore(self.store, observe: {$0}) { viewStore in
+        WithPerceptionTracking {
             ZStack {
                 Color.white
-                
+
                 VStack {
-                    if viewStore.state.isScrolledDown {
+                    if store.state.isScrolledDown {
                         scrollUpLabel
                             .padding(.top, 33)
                             .padding(.bottom, 16)
@@ -34,9 +34,13 @@ struct PeepPreviewModalView: View {
                         }
                         .padding(.top, 37)
                         .padding(.horizontal, 18)
+                        .padding(.bottom, 24)
                     }
+
+                    Spacer()
                 }
             }
+            .ignoresSafeArea()
         }
     }
 


### PR DESCRIPTION
## 연관된 이슈
#8

## 작업 요약
커스텀 홈 모달 시트 구현

## 작업 내용
- 기본 모달 시트 -> 커스텀으로 변경 (쉬운 화면 전환 및 배경 커스텀 위해)
- 모달 시트 내 화면 연결
- 모달 시트 내 셀 탭할 시 핍상세뷰로 이동

## 스크린샷
https://github.com/user-attachments/assets/3c885bc1-8518-4ebf-ac3b-841a9937ad31



