### PR TITLE
[#57] 타 유저 프로필 GUI

### DIFF
--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AB26A8292CB2ED99007D432E /* ProfileInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB26A8282CB2ED99007D432E /* ProfileInfoStore.swift */; };
 		AB416D142CF2EF040065BD09 /* TagTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416D132CF2EF040065BD09 /* TagTab.swift */; };
 		AB416D172CF2F7C10065BD09 /* ThumbnailProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */; };
+		AB416D1A2CF309750065BD09 /* ElseMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416D192CF309750065BD09 /* ElseMenuView.swift */; };
 		AB468D0B2CA8820A00C1E430 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D0A2CA8820A00C1E430 /* SettingView.swift */; };
 		AB468D0D2CA8821600C1E430 /* SettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D0C2CA8821600C1E430 /* SettingStore.swift */; };
 		AB468D132CA93F7D00C1E430 /* SideMenuType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D122CA93F7D00C1E430 /* SideMenuType.swift */; };
@@ -136,6 +137,7 @@
 		AB26A8282CB2ED99007D432E /* ProfileInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoStore.swift; sourceTree = "<group>"; };
 		AB416D132CF2EF040065BD09 /* TagTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTab.swift; sourceTree = "<group>"; };
 		AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailProfile.swift; sourceTree = "<group>"; };
+		AB416D192CF309750065BD09 /* ElseMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElseMenuView.swift; sourceTree = "<group>"; };
 		AB468D0A2CA8820A00C1E430 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		AB468D0C2CA8821600C1E430 /* SettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStore.swift; sourceTree = "<group>"; };
 		AB468D122CA93F7D00C1E430 /* SideMenuType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuType.swift; sourceTree = "<group>"; };
@@ -304,6 +306,14 @@
 				AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */,
 			);
 			path = Video;
+			sourceTree = "<group>";
+		};
+		AB416D182CF309620065BD09 /* Interface */ = {
+			isa = PBXGroup;
+			children = (
+				AB416D192CF309750065BD09 /* ElseMenuView.swift */,
+			);
+			path = Interface;
 			sourceTree = "<group>";
 		};
 		AB468D092CA881FB00C1E430 /* Setting */ = {
@@ -625,6 +635,7 @@
 				ABB96D212CD25145003C6742 /* Views */,
 				AB416D122CF2EEF20065BD09 /* Toggle */,
 				AB416D152CF2F7AF0065BD09 /* Video */,
+				AB416D182CF309620065BD09 /* Interface */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -939,6 +950,7 @@
 				AB26A8252CB2DF26007D432E /* InputIdStore.swift in Sources */,
 				AB71E1C82CBC065600D2D3D9 /* EditView.swift in Sources */,
 				ABDD3EC82CEB867C00A60C01 /* BackImageLayer.swift in Sources */,
+				AB416D1A2CF309750065BD09 /* ElseMenuView.swift in Sources */,
 				ABC171F12CAB198100370901 /* NicknameView.swift in Sources */,
 				AB469C732C9FF7F000DC7B8A /* SideMenuStore.swift in Sources */,
 				ABC305F32C95A567003B00FE /* UserProfile.swift in Sources */,

--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		AB26A8252CB2DF26007D432E /* InputIdStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB26A8242CB2DF26007D432E /* InputIdStore.swift */; };
 		AB26A8272CB2ED90007D432E /* ProfileInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB26A8262CB2ED90007D432E /* ProfileInfoView.swift */; };
 		AB26A8292CB2ED99007D432E /* ProfileInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB26A8282CB2ED99007D432E /* ProfileInfoStore.swift */; };
+		AB416D142CF2EF040065BD09 /* TagTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416D132CF2EF040065BD09 /* TagTab.swift */; };
+		AB416D172CF2F7C10065BD09 /* ThumbnailProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */; };
 		AB468D0B2CA8820A00C1E430 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D0A2CA8820A00C1E430 /* SettingView.swift */; };
 		AB468D0D2CA8821600C1E430 /* SettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D0C2CA8821600C1E430 /* SettingStore.swift */; };
 		AB468D132CA93F7D00C1E430 /* SideMenuType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB468D122CA93F7D00C1E430 /* SideMenuType.swift */; };
@@ -132,6 +134,8 @@
 		AB26A8242CB2DF26007D432E /* InputIdStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputIdStore.swift; sourceTree = "<group>"; };
 		AB26A8262CB2ED90007D432E /* ProfileInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoView.swift; sourceTree = "<group>"; };
 		AB26A8282CB2ED99007D432E /* ProfileInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoStore.swift; sourceTree = "<group>"; };
+		AB416D132CF2EF040065BD09 /* TagTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTab.swift; sourceTree = "<group>"; };
+		AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailProfile.swift; sourceTree = "<group>"; };
 		AB468D0A2CA8820A00C1E430 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		AB468D0C2CA8821600C1E430 /* SettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStore.swift; sourceTree = "<group>"; };
 		AB468D122CA93F7D00C1E430 /* SideMenuType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuType.swift; sourceTree = "<group>"; };
@@ -284,6 +288,22 @@
 				AB8A25852CD7EC1A0007A7A8 /* String+Extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		AB416D122CF2EEF20065BD09 /* Toggle */ = {
+			isa = PBXGroup;
+			children = (
+				AB416D132CF2EF040065BD09 /* TagTab.swift */,
+			);
+			path = Toggle;
+			sourceTree = "<group>";
+		};
+		AB416D152CF2F7AF0065BD09 /* Video */ = {
+			isa = PBXGroup;
+			children = (
+				AB416D162CF2F7C10065BD09 /* ThumbnailProfile.swift */,
+			);
+			path = Video;
 			sourceTree = "<group>";
 		};
 		AB468D092CA881FB00C1E430 /* Setting */ = {
@@ -603,6 +623,8 @@
 			children = (
 				ABC305F62C95C8D7003B00FE /* Modifiers */,
 				ABB96D212CD25145003C6742 /* Views */,
+				AB416D122CF2EEF20065BD09 /* Toggle */,
+				AB416D152CF2F7AF0065BD09 /* Video */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -920,6 +942,7 @@
 				ABC171F12CAB198100370901 /* NicknameView.swift in Sources */,
 				AB469C732C9FF7F000DC7B8A /* SideMenuStore.swift in Sources */,
 				ABC305F32C95A567003B00FE /* UserProfile.swift in Sources */,
+				AB416D142CF2EF040065BD09 /* TagTab.swift in Sources */,
 				ABB444992CA8452900C1EE67 /* RootStore.swift in Sources */,
 				ABC171F82CAB19E200370901 /* TermStore.swift in Sources */,
 				AB5159762CA97A320043AA0A /* MainGrayButtonStyle.swift in Sources */,
@@ -968,6 +991,7 @@
 				ABD3CAB92CA1BF3900438747 /* OtherProfileStore.swift in Sources */,
 				ABE8A0CD2CEAEFF100AFBEAE /* PressableButtonStyle.swift in Sources */,
 				AB26A8272CB2ED90007D432E /* ProfileInfoView.swift in Sources */,
+				AB416D172CF2F7C10065BD09 /* ThumbnailProfile.swift in Sources */,
 				AB51597F2CAAFA670043AA0A /* LoginView.swift in Sources */,
 				ABE8A0CB2CEAEAB100AFBEAE /* BackMapLayer.swift in Sources */,
 				ABCC50E52CEF90FF004AD297 /* GuideView.swift in Sources */,

--- a/PeepIt/PeepIt/Components/Interface/ElseMenuView.swift
+++ b/PeepIt/PeepIt/Components/Interface/ElseMenuView.swift
@@ -1,0 +1,32 @@
+//
+//  ElseMenuView.swift
+//  PeepIt
+//
+//  Created by 김민 on 11/24/24.
+//
+
+import SwiftUI
+
+struct ElseMenuView<First: View, Second: View>: View {
+    var firstButton: First
+    var secondButton: Second
+    let bgColor: Color
+
+    var body: some View {
+        VStack(spacing: 9) {
+            firstButton
+
+            Rectangle()
+                .frame(width: 108, height: 0.45)
+                .foregroundStyle(Color.op)
+
+            secondButton
+        }
+        .padding(.vertical, 17)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(bgColor)
+                .frame(width: 146)
+        )
+    }
+}

--- a/PeepIt/PeepIt/Components/Toggle/TagTab.swift
+++ b/PeepIt/PeepIt/Components/Toggle/TagTab.swift
@@ -1,0 +1,42 @@
+//
+//  TagTab.swift
+//  PeepIt
+//
+//  Created by 김민 on 11/24/24.
+//
+
+import SwiftUI
+
+struct TagTab: View {
+    let title: String
+    let isSelected: Bool
+
+    var body: some View {
+        Text(title)
+            .pretendard(.caption02)
+            .foregroundStyle(isSelected ? .white : .gray300)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 14)
+            .background {
+                RoundedRectangle(cornerRadius: 100)
+                    .fill(
+                        isSelected ?
+                        Color(hex: 0xA9D000) : Color.gray700
+                    )
+            }
+    }
+}
+
+#Preview {
+    VStack {
+        TagTab(
+            title: "태그",
+            isSelected: true
+        )
+
+        TagTab(
+            title: "태그",
+            isSelected: false
+        )
+    }
+}

--- a/PeepIt/PeepIt/Components/Video/ThumbnailProfile.swift
+++ b/PeepIt/PeepIt/Components/Video/ThumbnailProfile.swift
@@ -1,0 +1,43 @@
+//
+//  ThumbnailProfile.swift
+//  PeepIt
+//
+//  Created by 김민 on 11/24/24.
+//
+
+import SwiftUI
+
+struct ThumbnailProfile: View {
+    let peep: Peep
+
+    var body: some View {
+        ZStack {
+            // TODO: 이미지로 변경
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white)
+
+            ThumbnailLayer.primary()
+
+            ThumbnailLayer.secondary()
+
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(
+                    Color.coreLime,
+                    lineWidth: peep.isActive ? 1 : 0
+                )
+        }
+        .frame(width: 113, height: 155)
+    }
+}
+
+#Preview {
+    HStack {
+        ThumbnailProfile(
+            peep: .stubPeep0
+        )
+
+        ThumbnailProfile(
+            peep: .stubPeep1
+        )
+    }
+}

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -31,9 +31,13 @@ struct PeepDetailView: View {
                 .padding(.horizontal, 16.adjustedW)
 
                 if store.state.showElseMenu {
-                    menuView
-                        .padding(.top, 59)
-                        .padding(.trailing, 36.adjustedW)
+                    ElseMenuView(
+                        firstButton: shareButton,
+                        secondButton: reportButton,
+                        bgColor: Color.blur2
+                    )
+                    .padding(.top, 59)
+                    .padding(.trailing, 36.adjustedW)
                 }
             }
             .ignoresSafeArea(.all, edges: .bottom)

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -197,16 +197,21 @@ extension PeepDetailView {
     }
 
     private var nameView: some View {
-        HStack {
-            Image("ProfileSample")
-                .resizable()
-                .frame(width: 37.62, height: 37.62)
-            Text("hyerim")
-                .pretendard(.headline)
-            Text("3분 전")
-                .pretendard(.caption04)
+        NavigationLink(
+            state: RootStore.Path.State.otherProfile(OtherProfileStore.State())
+        ) {
+            HStack {
+                Image("ProfileSample")
+                    .resizable()
+                    .frame(width: 37.62, height: 37.62)
+                Text("hyerim")
+                    .pretendard(.headline)
+                Text("3분 전")
+                    .pretendard(.caption04)
 
-            Spacer()
+                Spacer()
+            }
+            .foregroundStyle(Color.white)
         }
     }
 
@@ -279,7 +284,11 @@ extension PeepDetailView {
 }
 
 #Preview {
-    PeepDetailView(
-        store: .init(initialState: PeepDetailStore.State()) { PeepDetailStore() }
-    )
+    NavigationStack {
+        PeepDetailView(
+            store: .init(initialState: PeepDetailStore.State()) {
+                PeepDetailStore()
+            }
+        )
+    }
 }

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
@@ -13,11 +13,25 @@ struct OtherProfileStore {
 
     @ObservableState
     struct State: Equatable {
-//        var uploadedPeeps: [Peep] = [.stubPeep0, .stubPeep1, .stubPeep2, .stubPeep3]
-        var uploadedPeeps: [Peep] = []
+        /// 핍 리스트
+        var uploadedPeeps: [Peep] = [.stubPeep0, .stubPeep1, .stubPeep2, .stubPeep3]
+        /// 상단 우측 더보기 버튼 탭 여부
+        var isElseButtonTapped = false
     }
 
     enum Action {
+        case elseButtonTapped(_ newState: Bool)
+    }
 
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+                
+            case let .elseButtonTapped(newState):
+                state.isElseButtonTapped = newState
+
+                return .none
+            }
+        }
     }
 }

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
@@ -21,7 +21,10 @@ struct OtherProfileStore {
 
     enum Action {
         case elseButtonTapped(_ newState: Bool)
+        case backButtonTapped
     }
+
+    @Dependency(\.dismiss) var dismiss
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
@@ -31,6 +34,11 @@ struct OtherProfileStore {
                 state.isElseButtonTapped = newState
 
                 return .none
+
+            case .backButtonTapped:
+                return .run { _ in
+                    await self.dismiss()
+                }
             }
         }
     }

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
@@ -13,7 +13,8 @@ struct OtherProfileStore {
 
     @ObservableState
     struct State: Equatable {
-        var uploadedPeeps = [Peep]()
+//        var uploadedPeeps: [Peep] = [.stubPeep0, .stubPeep1, .stubPeep2, .stubPeep3]
+        var uploadedPeeps: [Peep] = []
     }
 
     enum Action {

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -13,29 +13,43 @@ struct OtherProfileView: View {
 
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 0) {
+            ZStack(alignment: .topTrailing) {
+                Color.base
+                    .ignoresSafeArea()
 
-                PeepItNavigationBar(
-                    leading: backButton,
-                    title: "@아이디",
-                    trailing: elseButton
-                )
-                .padding(.bottom, 43.adjustedH)
+                VStack(spacing: 0) {
 
-                UserProfileView(profile: .stubUser2)
-                    .padding(.bottom, 68.adjustedH)
+                    PeepItNavigationBar(
+                        leading: backButton,
+                        title: "@아이디",
+                        trailing: elseButton
+                    )
+                    .padding(.bottom, 43.adjustedH)
 
-                Rectangle()
-                    .fill(Color.op)
-                    .frame(width: 361, height: 1)
+                    UserProfileView(profile: .stubUser2)
+                        .padding(.bottom, 68.adjustedH)
 
-                uploadPeepListView
+                    Rectangle()
+                        .fill(Color.op)
+                        .frame(width: 361, height: 1)
 
-                Spacer()
+                    uploadPeepListView
+
+                    Spacer()
+                }
+
+                if store.isElseButtonTapped {
+                    ElseMenuView(
+                        firstButton: shareButton,
+                        secondButton: blockButton,
+                        bgColor: .gray800
+                    )
+                    .padding(.top, 59)
+                    .padding(.trailing, 36.adjustedW)
+                }
             }
             .ignoresSafeArea(.all, edges: .bottom)
             .toolbar(.hidden, for: .navigationBar)
-            .background(Color.base)
         }
     }
 
@@ -47,7 +61,7 @@ struct OtherProfileView: View {
 
     private var elseButton: some View {
         Button {
-            // TODO:
+            store.send(.elseButtonTapped(!store.isElseButtonTapped))
         } label: {
             Rectangle()
                 .fill(Color.clear)
@@ -94,6 +108,63 @@ struct OtherProfileView: View {
             }
         }
         .frame(width: 361)
+    }
+
+    private var shareButton: some View {
+        Button {
+            // TODO: 공유하기
+        } label: {
+            HStack(spacing: 3) {
+                Image("CombiShareBtnN")
+                Text("공유하기")
+            }
+            .opacity(0)
+        }
+        .buttonStyle(
+            PressableViewButtonStyle(
+                normalView:
+                    HStack(spacing: 3) {
+                        Image("CombiShareBtnN")
+                        Text("공유하기")
+                    },
+                pressedView:
+                    HStack(spacing: 3) {
+                        Image("CombiShareBtnY")
+                        Text("공유하기")
+                            .pretendard(.body04)
+                    }
+                    .foregroundStyle(Color.gray300)
+            )
+        )
+    }
+
+    private var blockButton: some View {
+        Button {
+            // TODO: 차단하기
+        } label: {
+            HStack(spacing: 3) {
+                Image("CombiReportBtnN")
+                Text("차단하기")
+            }
+            .opacity(0)
+        }
+        .buttonStyle(
+            PressableViewButtonStyle(
+                normalView:
+                    HStack(spacing: 3) {
+                        Image("CombiReportBtnN")
+                        Text("차단하기")
+                    }
+                    .foregroundStyle(Color.coreRed),
+                pressedView:
+                    HStack(spacing: 3) {
+                        Image("CombiReportBtnY")
+                        Text("차단하기")
+                            .pretendard(.body04)
+                    }
+                    .foregroundStyle(Color.gray300)
+            )
+        )
     }
 }
 

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -55,7 +55,7 @@ struct OtherProfileView: View {
 
     private var backButton: some View {
         BackButton {
-            // TODO:
+            store.send(.backButtonTapped)
         }
     }
 

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -12,28 +12,31 @@ struct OtherProfileView: View {
     let store: StoreOf<OtherProfileStore>
 
     var body: some View {
-        VStack(spacing: 0) {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
 
-            PeepItNavigationBar(
-                leading: backButton,
-                title: "@아이디",
-                trailing: elseButton
-            )
-            .padding(.bottom, 49.adjustedH)
+                PeepItNavigationBar(
+                    leading: backButton,
+                    title: "@아이디",
+                    trailing: elseButton
+                )
+                .padding(.bottom, 43.adjustedH)
 
-            UserProfileView(profile: .stubUser2)
-                .padding(.bottom, 68.adjustedH)
+                UserProfileView(profile: .stubUser2)
+                    .padding(.bottom, 68.adjustedH)
 
-            Rectangle()
-                .fill(Color.op)
-                .frame(width: 361, height: 1)
+                Rectangle()
+                    .fill(Color.op)
+                    .frame(width: 361, height: 1)
 
-            uploadPeepListView
+                uploadPeepListView
 
-            Spacer()
+                Spacer()
+            }
+            .ignoresSafeArea(.all, edges: .bottom)
+            .toolbar(.hidden, for: .navigationBar)
+            .background(Color.base)
         }
-        .ignoresSafeArea(.all, edges: .bottom)
-        .background(Color.base)
     }
 
     private var backButton: some View {
@@ -57,26 +60,29 @@ struct OtherProfileView: View {
 
     private var uploadPeepListView: some View {
         let columns = [
-            GridItem(.flexible(), spacing: 13),
-            GridItem(.flexible(), spacing: 13),
+            GridItem(.flexible(), spacing: 11),
+            GridItem(.flexible(), spacing: 11),
             GridItem(.flexible())
         ]
 
         return Group {
             if store.uploadedPeeps.count > 0 {
-                HStack {
-                    Text("업로드한 핍")
-                    Spacer()
-                    Text("\(store.uploadedPeeps.count)")
-                }
-                .padding(.vertical, 17)
+                HStack(spacing: 5) {
+                    TagTab(title: "전체 00", isSelected: true)
+                    TagTab(title: "동이름 00", isSelected: false)
+                    TagTab(title: "동이름 00", isSelected: false)
 
-                ScrollView {
-                    LazyVGrid(columns: columns, spacing: 13) {
-                        ForEach(0..<17) { _ in
-                            RoundedRectangle(cornerRadius: 10)
-                                .aspectRatio(9/16, contentMode: .fit)
-                                .foregroundStyle(Color(uiColor: .lightGray))
+                    Spacer()
+                }
+                .padding(.top, 18.4.adjustedH)
+                .padding(.bottom, 21.adjustedH)
+
+                ScrollView(showsIndicators: false) {
+                    LazyVGrid(columns: columns, spacing: 11) {
+                        ForEach(
+                            store.uploadedPeeps
+                        ) { peep in
+                            ThumbnailProfile(peep: peep)
                         }
                     }
                 }
@@ -87,6 +93,7 @@ struct OtherProfileView: View {
                     .padding(.top, 161.adjustedH)
             }
         }
+        .frame(width: 361)
     }
 }
 

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -13,40 +13,46 @@ struct OtherProfileView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            topBar
-                .padding(.bottom, 29)
+
+            PeepItNavigationBar(
+                leading: backButton,
+                title: "@아이디",
+                trailing: elseButton
+            )
+            .padding(.bottom, 49.adjustedH)
 
             UserProfileView(profile: .stubUser2)
-                .padding(.bottom, 56)
+                .padding(.bottom, 68.adjustedH)
+
+            Rectangle()
+                .fill(Color.op)
+                .frame(width: 361, height: 1)
 
             uploadPeepListView
 
             Spacer()
         }
         .ignoresSafeArea(.all, edges: .bottom)
-        .padding(.horizontal, 22)
+        .background(Color.base)
     }
 
-    private var topBar: some View {
-        HStack {
-            Button {
-
-            } label: {
-                Text("뒤로")
-            }
-
-            Spacer()
-
-            Text("아이디")
-
-            Spacer()
-
-            Button {
-
-            } label: {
-                Text("더보기")
-            }
+    private var backButton: some View {
+        BackButton {
+            // TODO:
         }
+    }
+
+    private var elseButton: some View {
+        Button {
+            // TODO:
+        } label: {
+            Rectangle()
+                .fill(Color.clear)
+                .frame(width: 33.6, height: 33.6)
+        }
+        .buttonStyle(
+            PressableButtonStyle(originImg: "ElseN", pressedImg: "ElseY")
+        )
     }
 
     private var uploadPeepListView: some View {
@@ -75,9 +81,10 @@ struct OtherProfileView: View {
                     }
                 }
             } else {
-                Text("아직 등록된 핍이 없어요")
-                    .font(.system(size: 16))
-                    .padding(.top, 100)
+                Text("아직 등록된 핍이 없어요.")
+                    .pretendard(.body04)
+                    .foregroundStyle(Color.nonOp)
+                    .padding(.top, 161.adjustedH)
             }
         }
     }

--- a/PeepIt/PeepIt/Features/Profile/SubViews/UserProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/SubViews/UserProfileView.swift
@@ -11,16 +11,23 @@ struct UserProfileView: View {
     let profile: UserProfile
 
     var body: some View {
-        HStack(spacing: 20) {
-            Circle()
-                .frame(width: 97, height: 97)
+        VStack(spacing: 0) {
+            Image("ProfileSample")
+                .frame(width: 91.2, height: 91.2)
+                .padding(.bottom, 33.adjustedH)
 
-            VStack(alignment: .leading, spacing: 17) {
-                Text("\(profile.nickname)")
-                Text("\(profile.town)")
+            Text(profile.nickname)
+                .pretendard(.title02)
+                .padding(.bottom, 11.adjustedH)
+
+            HStack(spacing: 2) {
+                Image("IconLocation")
+                    .resizable()
+                    .frame(width: 22.4, height: 22.4)
+
+                Text("동이름")
+                    .pretendard(.body02)
             }
-
-            Spacer()
         }
     }
 }

--- a/PeepIt/PeepIt/Features/Root/RootStore.swift
+++ b/PeepIt/PeepIt/Features/Root/RootStore.swift
@@ -34,6 +34,9 @@ struct RootStore {
         /// 설정
         case setting(SettingStore)
         case guide(GuideStore)
+
+        /// 프로필
+        case otherProfile(OtherProfileStore)
     }
 
     @ObservableState

--- a/PeepIt/PeepIt/Features/Root/RootView.swift
+++ b/PeepIt/PeepIt/Features/Root/RootView.swift
@@ -81,6 +81,10 @@ struct RootView: View {
 
                 case let .guide(store):
                     GuideView(store: store)
+
+                /// 프로필
+                case let .otherProfile(store):
+                    OtherProfileView(store: store)
                 }
             }
         }

--- a/PeepIt/PeepIt/Models/Peep.swift
+++ b/PeepIt/PeepIt/Models/Peep.swift
@@ -7,6 +7,55 @@
 
 import Foundation
 
-struct Peep: Equatable, Hashable {
-    
+struct Peep: Equatable, Hashable, Identifiable {
+    let peepId: Int
+    let image: String
+    let content: String
+    let writerId: String
+    let isActive: Bool
+
+    var id: Int { peepId }
+}
+
+extension Peep {
+
+    static var stubPeep0: Peep {
+        return .init(
+            peepId: 0,
+            image: "",
+            content: "본문본문0",
+            writerId: "1",
+            isActive: true
+        )
+    }
+
+    static var stubPeep1: Peep {
+        return .init(
+            peepId: 1,
+            image: "",
+            content: "본문본문1",
+            writerId: "1",
+            isActive: false
+        )
+    }
+
+    static var stubPeep2: Peep {
+        return .init(
+            peepId: 2,
+            image: "",
+            content: "본문본문2",
+            writerId: "2",
+            isActive: true
+        )
+    }
+
+    static var stubPeep3: Peep {
+        return .init(
+            peepId: 3,
+            image: "",
+            content: "본문본문3",
+            writerId: "2",
+            isActive: false
+        )
+    }
 }

--- a/PeepIt/PeepIt/PeepItApp.swift
+++ b/PeepIt/PeepIt/PeepItApp.swift
@@ -11,14 +11,8 @@ import SwiftUI
 struct PeepItApp: App {
     var body: some Scene {
         WindowGroup {
-//            RootView(
-//                store: .init(initialState: RootStore.State()) { RootStore() }
-//            )
-
-            OtherProfileView(
-                store: .init(initialState: OtherProfileStore.State()) {
-                    OtherProfileStore()
-                }
+            RootView(
+                store: .init(initialState: RootStore.State()) { RootStore() }
             )
         }
     }

--- a/PeepIt/PeepIt/PeepItApp.swift
+++ b/PeepIt/PeepIt/PeepItApp.swift
@@ -11,8 +11,14 @@ import SwiftUI
 struct PeepItApp: App {
     var body: some Scene {
         WindowGroup {
-            RootView(
-                store: .init(initialState: RootStore.State()) { RootStore() }
+//            RootView(
+//                store: .init(initialState: RootStore.State()) { RootStore() }
+//            )
+
+            OtherProfileView(
+                store: .init(initialState: OtherProfileStore.State()) {
+                    OtherProfileStore()
+                }
             )
         }
     }


### PR DESCRIPTION
## 연관된 이슈
#57 

## 작업 요약
타 유저 프로필 GUI

## 작업 내용
- 타 유저 프로필 GUI 
- 필요한 컴포넌트 추가(`더보기 메뉴`, `썸네일`)
- 디테일뷰 -> 타유저 프로필 화면 전환

## 스크린샷

https://github.com/user-attachments/assets/ec650fa6-6337-42ff-8b82-39108ca4b0f9