### PR TITLE
[#127] 스크롤 애니메이션 오류 해결

### DIFF
--- a/PeepIt/PeepIt/Features/PeepPreview/PeepModalCollectionViewController.swift
+++ b/PeepIt/PeepIt/Features/PeepPreview/PeepModalCollectionViewController.swift
@@ -120,6 +120,7 @@ class PeepModalCollectionViewController: UICollectionViewController {
     func scrollToItem(at index: Int, animated: Bool = true) {
         guard index >= 0, index < peeps.count else { return }
         let indexPath = IndexPath(item: index, section: 0)
+        centerIdx = indexPath.item
         collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
     }
 }

--- a/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewModalView.swift
+++ b/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewModalView.swift
@@ -103,7 +103,7 @@ struct PeepPreviewModalView: View {
             if idx == 0 {
                 return -30
             } else if idx == store.peeps.count - 1 {
-                return 100
+                return 30
             } else {
                 return .zero
             }


### PR DESCRIPTION
## 연관된 이슈
#127 

## 작업 요약
스크롤 애니메이션 오류 해결

## 작업 내용
- `UICollectionView`의 `ScrollToItem` 로직의 item이 centerIdx가 되도록 함
