### PR TITLE
[#142] 전화번호 중복 api 호출 로직 작성

### DIFF
--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		AB4BEE002D967FDA00CA3936 /* CheckPhoneRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4BEDFF2D967FD800CA3936 /* CheckPhoneRequestDto.swift */; };
 		AB4BEE022D96802A00CA3936 /* IdCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4BEE012D96802100CA3936 /* IdCheckRequestDto.swift */; };
 		AB4BEE042D96813500CA3936 /* AuthAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4BEE032D96813200CA3936 /* AuthAPIClient.swift */; };
+		AB4BEE0B2D9A945900CA3936 /* PopUpBView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4BEE0A2D9A945900CA3936 /* PopUpBView.swift */; };
 		AB4F35BF2D6238AF00F799ED /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4F35BE2D6238AF00F799ED /* ShareSheet.swift */; };
 		AB51597F2CAAFA670043AA0A /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB51597E2CAAFA670043AA0A /* LoginView.swift */; };
 		AB5159812CAAFA730043AA0A /* LoginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5159802CAAFA730043AA0A /* LoginStore.swift */; };
@@ -279,6 +280,7 @@
 		AB4BEDFF2D967FD800CA3936 /* CheckPhoneRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPhoneRequestDto.swift; sourceTree = "<group>"; };
 		AB4BEE012D96802100CA3936 /* IdCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB4BEE032D96813200CA3936 /* AuthAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIClient.swift; sourceTree = "<group>"; };
+		AB4BEE0A2D9A945900CA3936 /* PopUpBView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpBView.swift; sourceTree = "<group>"; };
 		AB4F35BE2D6238AF00F799ED /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		AB51597E2CAAFA670043AA0A /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		AB5159802CAAFA730043AA0A /* LoginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStore.swift; sourceTree = "<group>"; };
@@ -722,6 +724,22 @@
 			path = Reqeust;
 			sourceTree = "<group>";
 		};
+		AB4BEE062D9A941700CA3936 /* Alarm */ = {
+			isa = PBXGroup;
+			children = (
+				AB4BEE072D9A944200CA3936 /* PopUp */,
+			);
+			path = Alarm;
+			sourceTree = "<group>";
+		};
+		AB4BEE072D9A944200CA3936 /* PopUp */ = {
+			isa = PBXGroup;
+			children = (
+				AB4BEE0A2D9A945900CA3936 /* PopUpBView.swift */,
+			);
+			path = PopUp;
+			sourceTree = "<group>";
+		};
 		AB5159772CA97C9C0043AA0A /* Constant */ = {
 			isa = PBXGroup;
 			children = (
@@ -1009,6 +1027,7 @@
 				AB416D152CF2F7AF0065BD09 /* Video */,
 				AB416D182CF309620065BD09 /* Interface */,
 				AB416D1D2CF329490065BD09 /* Text */,
+				AB4BEE062D9A941700CA3936 /* Alarm */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1505,6 +1524,7 @@
 				ABCC50ED2CF03359004AD297 /* PeepItNavigationBar.swift in Sources */,
 				AB11FFCF2CF77EAC0095B818 /* ReportStore.swift in Sources */,
 				ABB444962CA8451900C1EE67 /* RootView.swift in Sources */,
+				AB4BEE0B2D9A945900CA3936 /* PopUpBView.swift in Sources */,
 				AB71E1D42CBC254600D2D3D9 /* StickerModalView.swift in Sources */,
 				AB4BEDDF2D926EF600CA3936 /* CommonPeepDto.swift in Sources */,
 				AB53DE532CA0123D00D8DC1F /* PeepModalStore.swift in Sources */,

--- a/PeepIt/PeepIt/Components/Alarm/PopUp/PopUpBView.swift
+++ b/PeepIt/PeepIt/Components/Alarm/PopUp/PopUpBView.swift
@@ -1,0 +1,62 @@
+//
+//  PopUpAView.swift
+//  PeepIt
+//
+//  Created by 김민 on 3/31/25.
+//
+
+import SwiftUI
+
+struct PopUpBView: View {
+    let title: String
+    let description: String
+    let buttonLabel: String
+    let action: () -> Void
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 25)
+                .fill(Color.gray600)
+
+            VStack(spacing: 0) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 11) {
+                        Text(title)
+                            .pretendard(.title03)
+
+                        Text(description)
+                            .pretendard(.body03)
+                            .frame(height: 71, alignment: .topLeading)
+                    }
+
+                    Spacer()
+                }
+                .padding(.horizontal, 5)
+                .frame(width: 294, height: 110)
+
+                Button {
+                    action()
+                } label: {
+                    Text(buttonLabel)
+                        .pretendard(.headline)
+                        .foregroundStyle(Color.gray600)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                }
+                .frame(width: 289, height: 50)
+                .background(Color.coreLime)
+                .clipShape(RoundedRectangle(cornerRadius: 15))
+            }
+        }
+        .frame(width: 329, height: 222)
+    }
+}
+
+#Preview {
+    PopUpBView(
+        title: "알림 제목",
+        description: "알림 내용",
+        buttonLabel: "텍스트",
+        action: { print("hello") }
+    )
+}

--- a/PeepIt/PeepIt/Components/Alarm/PopUp/PopUpBView.swift
+++ b/PeepIt/PeepIt/Components/Alarm/PopUp/PopUpBView.swift
@@ -24,7 +24,7 @@ struct PopUpBView: View {
                         Text(title)
                             .pretendard(.title03)
 
-                        Text(description)
+                        Text(description.forceCharWrapping)
                             .pretendard(.body03)
                             .frame(height: 71, alignment: .topLeading)
                     }
@@ -54,9 +54,9 @@ struct PopUpBView: View {
 
 #Preview {
     PopUpBView(
-        title: "알림 제목",
-        description: "알림 내용",
-        buttonLabel: "텍스트",
-        action: { print("hello") }
+        title: "이미 사용 중인 번호입니다.",
+        description: "입력된 전화번호가 올바른지 다시 한 번 확인해주세요.",
+        buttonLabel: "네",
+        action: { }
     )
 }

--- a/PeepIt/PeepIt/Components/Views/CheckEnterFieldStore.swift
+++ b/PeepIt/PeepIt/Components/Views/CheckEnterFieldStore.swift
@@ -87,7 +87,7 @@ struct CheckEnterFieldStore {
                     })
                     .debounce(
                         id: ID.debounce,
-                        for: 0.5,
+                        for: 0.2,
                         scheduler: DispatchQueue.main
                     )
                 }

--- a/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationStore.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationStore.swift
@@ -44,6 +44,7 @@ struct AuthenticationStore {
         case nextButtonTapped
         case backButtonTapped
         case debouncedText(newText: String)
+        case popButtonTapped
 
         /// 전화번호 중복체크 api
         case checkPhoneNumberDuplicated
@@ -66,7 +67,7 @@ struct AuthenticationStore {
                     }
                     .debounce(
                         id: ID.debounce,
-                        for: 0.5,
+                        for: 0.2,
                         scheduler: DispatchQueue.main
                     )
                 }
@@ -113,6 +114,12 @@ struct AuthenticationStore {
                 }
 
             case let .fetchPhoneNumberCheckResponse(result):
+                // TODO: 입력받은 result 기반으로 변경
+                state.isDuplicated = true
+                return .none
+
+            case .popButtonTapped:
+                state.isDuplicated = false
                 return .none
 
             default:

--- a/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationView.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationView.swift
@@ -48,6 +48,16 @@ struct AuthenticationView: View {
                 .padding(.bottom, 36)
             }
             .background(Color.base)
+            .overlay {
+                if store.isDuplicated {
+                    PopUpBView(
+                        title: "이미 사용 중인 번호입니다.",
+                        description: "입력된 전화번호가 올바른지 다시 한 번 확인해주세요.",
+                        buttonLabel: "네",
+                        action: { store.send(.popButtonTapped) }
+                    )
+                }
+            }
             .toolbar(.hidden, for: .navigationBar)
             .onAppear {
                 isFocused = true

--- a/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationView.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Authentication/EnterPhoneNumber/AuthenticationView.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 struct AuthenticationView: View {
     @Perception.Bindable var store: StoreOf<AuthenticationStore>
 
+    @State private var keyboardHeight: CGFloat = 0
     @FocusState var isFocused: Bool
 
     var body: some View {
@@ -56,6 +57,7 @@ struct AuthenticationView: View {
                         buttonLabel: "네",
                         action: { store.send(.popButtonTapped) }
                     )
+                    .offset(y: 100)
                 }
             }
             .toolbar(.hidden, for: .navigationBar)


### PR DESCRIPTION
## 연관된 이슈
#142 

## 작업 요약
전화번호 중복 api 호출 로직 작성

## 작업 내용
- debounce된 전화번호로 올바른 11자리 전화번호 작성 시 전화번호 중복 검증 api 호출
- 중복되었을 시 B타입 팝업 띄움
- 현재 중복된 전화번호 이용 불가하여, api 응답 완료 시엔 무조건 중복 로직으로 연결되도록 함