### PR TITLE
[#165] 프로필 이미지 api 연결

### DIFF
--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		AB3340322DAD6616007C31FC /* ModifyTownRequestDTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340312DAD660C007C31FC /* ModifyTownRequestDTo.swift */; };
 		AB3340342DAD701B007C31FC /* MapInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340332DAD7015007C31FC /* MapInteractionState.swift */; };
 		AB3340362DAE2289007C31FC /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340352DAE2282007C31FC /* UIImage+Extension.swift */; };
+		AB3340382DAE24F7007C31FC /* MultipartFormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */; };
+		AB33403B2DAE2624007C31FC /* ProfileImgRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */; };
 		AB33888A2D9EA87400316D4B /* CodeCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */; };
 		AB33888D2DA02D6E00316D4B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888C2DA02D6B00316D4B /* MapView.swift */; };
 		AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888E2DA2DBFF00316D4B /* LoginRequestDto.swift */; };
@@ -268,6 +270,8 @@
 		AB3340312DAD660C007C31FC /* ModifyTownRequestDTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyTownRequestDTo.swift; sourceTree = "<group>"; };
 		AB3340332DAD7015007C31FC /* MapInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapInteractionState.swift; sourceTree = "<group>"; };
 		AB3340352DAE2282007C31FC /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
+		AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataPart.swift; sourceTree = "<group>"; };
+		AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImgRequestDto.swift; sourceTree = "<group>"; };
 		AB3388862D9C606500316D4B /* PeepIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PeepIt.entitlements; sourceTree = "<group>"; };
 		AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB33888C2DA02D6B00316D4B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
@@ -577,6 +581,14 @@
 			path = API;
 			sourceTree = "<group>";
 		};
+		AB3340392DAE2615007C31FC /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
 		AB33888B2DA02D3400316D4B /* Map */ = {
 			isa = PBXGroup;
 			children = (
@@ -608,6 +620,7 @@
 			isa = PBXGroup;
 			children = (
 				AB3388972DA2DE0200316D4B /* Common */,
+				AB3340392DAE2615007C31FC /* Request */,
 				AB3340152DA4D796007C31FC /* Response */,
 			);
 			path = Dto;
@@ -655,6 +668,7 @@
 			children = (
 				ABD639D62D7EE7340062A60C /* Environment.swift */,
 				AB37049F2D7FFE2F00EBBC85 /* BaseResponse.swift */,
+				AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1602,6 +1616,7 @@
 				AB9788142D114B84007E73B6 /* BlockDescriptionModal.swift in Sources */,
 				AB3388962DA2DCB300316D4B /* SignUpDto.swift in Sources */,
 				AB3704992D7FFA2400EBBC85 /* PeepItError.swift in Sources */,
+				AB33403B2DAE2624007C31FC /* ProfileImgRequestDto.swift in Sources */,
 				ABD3CAB42CA1BE0100438747 /* UserProfileView.swift in Sources */,
 				AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */,
 				ABC171EF2CAB193F00370901 /* TermView.swift in Sources */,
@@ -1731,6 +1746,7 @@
 				ABCE972F2D31203F00A07962 /* StickerLayerStore.swift in Sources */,
 				AB468D312CA954C700C1E430 /* GenderType.swift in Sources */,
 				AB4BEDE72D9277F100CA3936 /* PeepAPI.swift in Sources */,
+				AB3340382DAE24F7007C31FC /* MultipartFormDataPart.swift in Sources */,
 				AB0778202CE730AA00E4F226 /* EnterAuthCodeView.swift in Sources */,
 				AB53DE552CA0289A00D8DC1F /* Chat.swift in Sources */,
 				AB47D6E32D6B836100934A0F /* CameraServiceKey.swift in Sources */,

--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		AB3340362DAE2289007C31FC /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340352DAE2282007C31FC /* UIImage+Extension.swift */; };
 		AB3340382DAE24F7007C31FC /* MultipartFormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */; };
 		AB33403B2DAE2624007C31FC /* ProfileImgRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */; };
+		AB33403D2DAE2E4A007C31FC /* UserProfileStorageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */; };
 		AB33888A2D9EA87400316D4B /* CodeCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */; };
 		AB33888D2DA02D6E00316D4B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888C2DA02D6B00316D4B /* MapView.swift */; };
 		AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888E2DA2DBFF00316D4B /* LoginRequestDto.swift */; };
@@ -272,6 +273,7 @@
 		AB3340352DAE2282007C31FC /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataPart.swift; sourceTree = "<group>"; };
 		AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImgRequestDto.swift; sourceTree = "<group>"; };
+		AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileStorageClient.swift; sourceTree = "<group>"; };
 		AB3388862D9C606500316D4B /* PeepIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PeepIt.entitlements; sourceTree = "<group>"; };
 		AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB33888C2DA02D6B00316D4B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
@@ -1060,6 +1062,7 @@
 				ABB444952CA8451900C1EE67 /* RootView.swift */,
 				ABB444982CA8452900C1EE67 /* RootStore.swift */,
 				AB6B525A2CD7D9D200BDC985 /* LaunchScreen.swift */,
+				AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */,
 			);
 			path = Root;
 			sourceTree = "<group>";
@@ -1667,6 +1670,7 @@
 				AB469C712C9FED6C00DC7B8A /* SideMenuView.swift in Sources */,
 				AB4BEDF32D928A8900CA3936 /* MapPeepRequest.swift in Sources */,
 				ABC305E92C933F08003B00FE /* ClearBackgroundViewModifier.swift in Sources */,
+				AB33403D2DAE2E4A007C31FC /* UserProfileStorageClient.swift in Sources */,
 				ABA11E9C2D21766300C181DC /* TownTitleView.swift in Sources */,
 				ABA9A2E22CCE932900AA605B /* Adjusted.swift in Sources */,
 				AB53DE5A2CA02D1F00D8DC1F /* ChatType.swift in Sources */,

--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		AB3340302DA50044007C31FC /* TownAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33402F2DA50041007C31FC /* TownAPIClient.swift */; };
 		AB3340322DAD6616007C31FC /* ModifyTownRequestDTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340312DAD660C007C31FC /* ModifyTownRequestDTo.swift */; };
 		AB3340342DAD701B007C31FC /* MapInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340332DAD7015007C31FC /* MapInteractionState.swift */; };
+		AB3340362DAE2289007C31FC /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340352DAE2282007C31FC /* UIImage+Extension.swift */; };
 		AB33888A2D9EA87400316D4B /* CodeCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */; };
 		AB33888D2DA02D6E00316D4B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888C2DA02D6B00316D4B /* MapView.swift */; };
 		AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888E2DA2DBFF00316D4B /* LoginRequestDto.swift */; };
@@ -266,6 +267,7 @@
 		AB33402F2DA50041007C31FC /* TownAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TownAPIClient.swift; sourceTree = "<group>"; };
 		AB3340312DAD660C007C31FC /* ModifyTownRequestDTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyTownRequestDTo.swift; sourceTree = "<group>"; };
 		AB3340332DAD7015007C31FC /* MapInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapInteractionState.swift; sourceTree = "<group>"; };
+		AB3340352DAE2282007C31FC /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		AB3388862D9C606500316D4B /* PeepIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PeepIt.entitlements; sourceTree = "<group>"; };
 		AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB33888C2DA02D6B00316D4B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 		AB094DE62CC76EB10091E9FB /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				AB3340352DAE2282007C31FC /* UIImage+Extension.swift */,
 				AB4BEDEC2D9279D800CA3936 /* Encodable+Extension.swift */,
 				ABA9A2E12CCE932900AA605B /* Adjusted.swift */,
 				ABF8E2EE2CD237780096A7EF /* UINavigationController+Extension.swift */,
@@ -1592,6 +1595,7 @@
 				AB5159832CAAFCA40043AA0A /* LoginType.swift in Sources */,
 				AB4BEE042D96813500CA3936 /* AuthAPIClient.swift in Sources */,
 				AB71E1CA2CBC065E00D2D3D9 /* EditStore.swift in Sources */,
+				AB3340362DAE2289007C31FC /* UIImage+Extension.swift in Sources */,
 				ABD3CAA52CA08D6C00438747 /* MyProfileStore.swift in Sources */,
 				AB416D342CF5F3890065BD09 /* BlockListStore.swift in Sources */,
 				AB416D242CF34B920065BD09 /* NotificationSettingStore.swift in Sources */,

--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		AB3340382DAE24F7007C31FC /* MultipartFormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */; };
 		AB33403B2DAE2624007C31FC /* ProfileImgRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */; };
 		AB33403D2DAE2E4A007C31FC /* UserProfileStorageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */; };
+		AB3340442DAE34E4007C31FC /* AsyncProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340432DAE34E4007C31FC /* AsyncProfile.swift */; };
 		AB33888A2D9EA87400316D4B /* CodeCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */; };
 		AB33888D2DA02D6E00316D4B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888C2DA02D6B00316D4B /* MapView.swift */; };
 		AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888E2DA2DBFF00316D4B /* LoginRequestDto.swift */; };
@@ -274,6 +275,7 @@
 		AB3340372DAE24F4007C31FC /* MultipartFormDataPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataPart.swift; sourceTree = "<group>"; };
 		AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImgRequestDto.swift; sourceTree = "<group>"; };
 		AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileStorageClient.swift; sourceTree = "<group>"; };
+		AB3340432DAE34E4007C31FC /* AsyncProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncProfile.swift; sourceTree = "<group>"; };
 		AB3388862D9C606500316D4B /* PeepIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PeepIt.entitlements; sourceTree = "<group>"; };
 		AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB33888C2DA02D6B00316D4B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
@@ -589,6 +591,14 @@
 				AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */,
 			);
 			path = Request;
+			sourceTree = "<group>";
+		};
+		AB33403E2DAE3480007C31FC /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				AB3340432DAE34E4007C31FC /* AsyncProfile.swift */,
+			);
+			path = UseCase;
 			sourceTree = "<group>";
 		};
 		AB33888B2DA02D3400316D4B /* Map */ = {
@@ -1237,6 +1247,7 @@
 				AB416D182CF309620065BD09 /* Interface */,
 				AB416D1D2CF329490065BD09 /* Text */,
 				AB4BEE062D9A941700CA3936 /* Alarm */,
+				AB33403E2DAE3480007C31FC /* UseCase */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1781,6 +1792,7 @@
 				AB4BEDDF2D926EF600CA3936 /* CommonPeepDto.swift in Sources */,
 				AB53DE532CA0123D00D8DC1F /* PeepModalStore.swift in Sources */,
 				AB4A28C92D3FD31A007E8383 /* HomeMapView.swift in Sources */,
+				AB3340442DAE34E4007C31FC /* AsyncProfile.swift in Sources */,
 				ABD631C12C9757AC00AFF299 /* PeepDetailView.swift in Sources */,
 				ABD3CAB02CA1B52000438747 /* Peep.swift in Sources */,
 				AB11FFCD2CF77EA10095B818 /* ReportModal.swift in Sources */,

--- a/PeepIt/PeepIt/Components/UseCase/AsyncProfile.swift
+++ b/PeepIt/PeepIt/Components/UseCase/AsyncProfile.swift
@@ -1,0 +1,28 @@
+//
+//  AsyncProfile.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import SwiftUI
+
+struct AsyncProfile: View {
+    let profileUrlStr: String?
+
+    var body: some View {
+        if let str = profileUrlStr, let url = URL(string: str) {
+            AsyncImage(url: url) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Image("ProfileSample")
+                    .resizable()
+            }
+        } else {
+            Image("ProfileSample")
+                .resizable()
+        }
+    }
+}

--- a/PeepIt/PeepIt/Features/Home/HomeStore.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeStore.swift
@@ -68,6 +68,8 @@ struct HomeStore {
         case peepTapped(idx: Int)
     }
 
+    @Dependency(\.userProfileStorage) var userProfileStorage
+
     var body: some Reducer<State, Action> {
         BindingReducer()
         

--- a/PeepIt/PeepIt/Features/Home/HomeStore.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeStore.swift
@@ -21,7 +21,6 @@ struct HomeStore {
 
         /// 핍 상세 보여주기 여부
         var showPeepDetail = false
-
         /// 동네 등록 모달 offsetY 관리
         var townVerificationModalOffset = Constant.screenHeight
         /// 동네 등록 모달 보여줄지 여부
@@ -36,6 +35,8 @@ struct HomeStore {
         var isDragged = false
         /// 현재 위치로 이동
         var moveToCurrentLocation = false
+        /// 프로필 정보
+        var userProfile: UserProfile?
     }
 
     enum Action: BindableAction {
@@ -46,6 +47,8 @@ struct HomeStore {
         case peepPreviewModal(PeepModalStore.Action)
         case townVerification(TownVerificationStore.Action)
 
+        /// 뷰 등장
+        case onAppear
         /// 사이드메뉴 버튼 탭
         case sideMenuButtonTapped
         /// 프로필 버튼 탭
@@ -64,8 +67,10 @@ struct HomeStore {
         case searchButtonTapped
         /// 현재 위치 버튼 탭
         case locationButtonTapped
-
+        /// 핍 탭
         case peepTapped(idx: Int)
+        /// 프로필 정보 업데이트
+        case updateProfile(profile: UserProfile)
     }
 
     @Dependency(\.userProfileStorage) var userProfileStorage
@@ -99,6 +104,13 @@ struct HomeStore {
 
             case .binding(\.moveToCurrentLocation):
                 return .none
+
+            case .onAppear:
+                return .run { send in
+                    if let savedProfile = try? await userProfileStorage.load() {
+                        await send(.updateProfile(profile: savedProfile))
+                    }
+                }
 
             case let .peepPreviewModal(.startEntryAnimation(idx, peeps)):
                 state.showPeepDetail = true
@@ -171,6 +183,10 @@ struct HomeStore {
 
             case .locationButtonTapped:
                 state.moveToCurrentLocation = true
+                return .none
+
+            case let .updateProfile(profile):
+                state.userProfile = profile
                 return .none
 
             default:

--- a/PeepIt/PeepIt/Features/Home/HomeView.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeView.swift
@@ -81,6 +81,7 @@ struct HomeView: View {
                     .animation(.easeInOut(duration: 0.3), value: store.mainViewOffset)
                     .ignoresSafeArea(.all, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
+                    .onAppear { store.send(.onAppear) }
                     .overlay {
                         /// 핍 상세
                         if store.showPeepDetail {
@@ -164,9 +165,23 @@ extension HomeView {
         Button {
             store.send(.profileButtonTapped)
         } label: {
-            Image("ProfileSample")
-                .resizable()
-                .frame(width: 45, height: 45)
+            Group {
+                if let str = store.userProfile?.profile,
+                   let url = URL(string: str) {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+
+                    } placeholder: {
+                        ProgressView()
+                    }
+                } else {
+                    Image("ProfileSample")
+                        .resizable()
+                }
+            }
+            .frame(width: 45, height: 45)
         }
         .buttonStyle(PressableOpacityButtonStyle())
         .clipShape(RoundedRectangle(cornerRadius: 13))

--- a/PeepIt/PeepIt/Features/Home/HomeView.swift
+++ b/PeepIt/PeepIt/Features/Home/HomeView.swift
@@ -165,23 +165,8 @@ extension HomeView {
         Button {
             store.send(.profileButtonTapped)
         } label: {
-            Group {
-                if let str = store.userProfile?.profile,
-                   let url = URL(string: str) {
-                    AsyncImage(url: url) { image in
-                        image
-                            .resizable()
-                            .scaledToFill()
-
-                    } placeholder: {
-                        ProgressView()
-                    }
-                } else {
-                    Image("ProfileSample")
-                        .resizable()
-                }
-            }
-            .frame(width: 45, height: 45)
+            AsyncProfile(profileUrlStr: store.userProfile?.profile)
+                .frame(width: 45, height: 45)
         }
         .buttonStyle(PressableOpacityButtonStyle())
         .clipShape(RoundedRectangle(cornerRadius: 13))

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
@@ -97,6 +97,7 @@ struct ProfileModifyStore {
                 state.profileImgStr = profile.profile
                 state.nickname = profile.name
                 state.id = profile.id
+                state.selectedGender = profile.gender
                 return .none
 
             default:

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
+import _PhotosUI_SwiftUI
 
 @Reducer
 struct ProfileModifyStore {
@@ -24,10 +25,15 @@ struct ProfileModifyStore {
         /// 입력창 히위 뷰 State
         var enterFieldState = CheckEnterFieldStore.State()
         /// 프로필
-        var profileImgStr: String?
+        var profileImgStr: String? = nil
+        /// PhotoPicker 변수
+        var selectedPhotoItem: PhotosPickerItem? = nil
+        /// 유저 프로필 정보
+        var userProfile: UserProfile?
     }
 
-    enum Action {
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
         /// 나타날 때
         case onAppear
         /// 이전 버튼 탭
@@ -40,14 +46,21 @@ struct ProfileModifyStore {
         case dismiss
         /// 하위뷰 액션 연결
         case enterFieldAction(CheckEnterFieldStore.Action)
-
+        /// 프로필 업데이트
         case updateProfile(profile: UserProfile)
+
+        /// 프로필 이미지 수정 api
+        case modifyMyProfileImg(data: Data)
+        case fetchModifyMyProfileImgResponse(Result<String, Error>)
     }
 
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.userProfileStorage) var userProfileStorage
+    @Dependency(\.memberAPIClient) var memberAPIClient
 
     var body: some Reducer<State, Action> {
+        BindingReducer()
+        
         Scope(
             state: \.enterFieldState,
             action: \.enterFieldAction
@@ -57,6 +70,15 @@ struct ProfileModifyStore {
 
         Reduce { state, action in
             switch action {
+
+            case .binding(\.selectedPhotoItem):
+                guard let photoItem = state.selectedPhotoItem else { return .none }
+
+                return .run { send in
+                    if let data = try? await photoItem.loadTransferable(type: Data.self) {
+                        await send(.modifyMyProfileImg(data: data))
+                    }
+                }
 
             case .onAppear:
                 state.enterFieldState.fieldType = .nickname
@@ -94,10 +116,44 @@ struct ProfileModifyStore {
                 return .run { _ in await self.dismiss() }
 
             case let .updateProfile(profile):
+                state.userProfile = profile
+
                 state.profileImgStr = profile.profile
                 state.nickname = profile.name
                 state.id = profile.id
                 state.selectedGender = profile.gender
+
+                return .none
+
+            case let .modifyMyProfileImg(data):
+                return .run { send in
+                    await send(
+                        .fetchModifyMyProfileImgResponse(
+                            Result { try await memberAPIClient.modifyUserProfileImage(data) }
+                        )
+                    )
+                }
+
+            case let .fetchModifyMyProfileImgResponse(result):
+                switch result {
+
+                case let .success(value):
+                    state.profileImgStr = value
+                    state.userProfile?.profile = value
+
+                    let newProfile = state.userProfile
+
+                    return .run { _ in
+                        if let newProfile = newProfile {
+                            try await userProfileStorage.save(newProfile)
+                        }
+                    }
+
+                case let .failure(error):
+                    // TODO: 오류
+                    print(error)
+                }
+
                 return .none
 
             default:

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
@@ -34,14 +34,15 @@ struct ProfileModifyView: View {
             }
             .background(Color.base)
             .toolbar(.hidden, for: .navigationBar)
+            .onAppear { store.send(.onAppear) }
         }
     }
 
     private var profileView: some View {
         VStack(spacing: 0) {
-            Image("ProfileSample")
-                .resizable()
+            AsyncProfile(profileUrlStr: store.profileImgStr)
                 .frame(width: 114, height: 114)
+                .clipShape(RoundedRectangle(cornerRadius: 21))
 
             Button {
 

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
@@ -94,7 +94,7 @@ struct ProfileModifyView: View {
         HStack(spacing: 23) {
             Text("성별")
                 .pretendard(.foodnote)
-            Text("선택된 성별")
+            Text(store.selectedGender?.title ?? "기타")
                 .pretendard(.body04)
 
             Spacer()

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyView.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 import ComposableArchitecture
+import PhotosUI
 
 struct ProfileModifyView: View {
-    let store: StoreOf<ProfileModifyStore>
+    @Perception.Bindable var store: StoreOf<ProfileModifyStore>
 
     var body: some View {
         WithPerceptionTracking {
@@ -44,14 +45,12 @@ struct ProfileModifyView: View {
                 .frame(width: 114, height: 114)
                 .clipShape(RoundedRectangle(cornerRadius: 21))
 
-            Button {
-
-            } label: {
+            PhotosPicker(selection: $store.selectedPhotoItem) {
                 Text("수정")
-                    .tint(.white)
-                    .pretendard(.caption04)
                     .underline()
-                    .frame(width: 44, height: 44)
+                    .pretendard(.caption02)
+                    .frame(width: 43, height: 44)
+                    .foregroundStyle(Color.white)
             }
         }
     }

--- a/PeepIt/PeepIt/Features/Root/UserProfileStorageClient.swift
+++ b/PeepIt/PeepIt/Features/Root/UserProfileStorageClient.swift
@@ -1,0 +1,43 @@
+//
+//  UserProfileStorageClient.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import Foundation
+import ComposableArchitecture
+import Dependencies
+
+struct UserProfileStorageClient {
+    var save: (UserProfile) async throws -> Void
+    var load: () async throws -> UserProfile?
+    var clear: () async throws -> Void
+}
+
+extension UserProfileStorageClient {
+    static let live = UserProfileStorageClient(
+        save: { profile in
+            let data = try JSONEncoder().encode(profile)
+            UserDefaults.standard.set(data, forKey: "user_profile")
+        },
+        load: {
+            guard let data = UserDefaults.standard.data(forKey: "user_profile") else { return nil }
+            return try JSONDecoder().decode(UserProfile.self, from: data)
+        },
+        clear: {
+            UserDefaults.standard.removeObject(forKey: "user_profile")
+        }
+    )
+}
+
+extension DependencyValues {
+    var userProfileStorage: UserProfileStorageClient {
+        get { self[UserProfileStorageKey.self] }
+        set { self[UserProfileStorageKey.self] = newValue }
+    }
+}
+
+private enum UserProfileStorageKey: DependencyKey {
+    static let liveValue: UserProfileStorageClient = .live
+}

--- a/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
@@ -16,8 +16,6 @@ struct WelcomeStore {
     struct State: Equatable {
         /// PhotoPicker 변수
         var selectedPhotoItem: PhotosPickerItem? = nil
-        /// 선택된 프로필 이미지
-        var selectedUIImage: UIImage? = nil
         /// 유저 프로필
         var myProfile: UserProfile?
         /// 인증 여부
@@ -30,12 +28,14 @@ struct WelcomeStore {
         case onAppear
         /// 홈으로 버튼 탭
         case goToHomeButtonTapped
-        /// 프로필 이미지 선택 시 설정
-        case updateSelectedImage(image: UIImage)
 
         /// 내 프로필 조회 api
         case getMyProfile
         case fetchGetMyProfileResponse(Result<UserProfile, Error>)
+
+        /// 프로필 이미지 수정 api
+        case modifyMyProfileImg(data: Data)
+        case fetchModifyMyProfileImgResponse(Result<String, Error>)
     }
 
     @Dependency(\.memberAPIClient) var memberAPIClient
@@ -50,9 +50,8 @@ struct WelcomeStore {
                 guard let photoItem = state.selectedPhotoItem else { return .none }
                 
                 return .run { send in
-                    if let data = try? await photoItem.loadTransferable(type: Data.self),
-                       let uiImage = UIImage(data: data)?.fixedOrientation() {
-                        await send(.updateSelectedImage(image: uiImage))
+                    if let data = try? await photoItem.loadTransferable(type: Data.self) {
+                        await send(.modifyMyProfileImg(data: data))
                     }
                 }
 
@@ -60,11 +59,6 @@ struct WelcomeStore {
                 return .send(.getMyProfile)
 
             case .goToHomeButtonTapped:
-                return .none
-
-            case let .updateSelectedImage(image):
-                state.selectedUIImage = image
-                // TODO: 사진 api 호출
                 return .none
 
             case .getMyProfile:
@@ -85,6 +79,29 @@ struct WelcomeStore {
                 case .failure:
                     // TODO: 오류 처리
                     print("오류")
+                }
+
+                return .none
+
+            case let .modifyMyProfileImg(data):
+                return .run { send in
+                    await send(
+                        .fetchModifyMyProfileImgResponse(
+                            Result { try await memberAPIClient.modifyUserProfileImage(data) }
+                        )
+                    )
+                }
+
+
+            case let .fetchModifyMyProfileImgResponse(result):
+                switch result {
+
+                case let .success(value):
+                    state.myProfile?.profile = value
+
+                case let .failure(error):
+                    // TODO: 오류
+                    print(error)
                 }
 
                 return .none

--- a/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
@@ -17,7 +17,7 @@ struct WelcomeStore {
         /// PhotoPicker 변수
         var selectedPhotoItem: PhotosPickerItem? = nil
         /// 선택된 프로필 이미지
-        var selectedImage: Image? = nil
+        var selectedUIImage: UIImage? = nil
         /// 유저 프로필
         var myProfile: UserProfile?
         /// 인증 여부
@@ -31,7 +31,7 @@ struct WelcomeStore {
         /// 홈으로 버튼 탭
         case goToHomeButtonTapped
         /// 프로필 이미지 선택 시 설정
-        case updateSelectedImage(image: Image)
+        case updateSelectedImage(image: UIImage)
 
         /// 내 프로필 조회 api
         case getMyProfile
@@ -50,8 +50,9 @@ struct WelcomeStore {
                 guard let photoItem = state.selectedPhotoItem else { return .none }
                 
                 return .run { send in
-                    if let image = try? await photoItem.loadTransferable(type: Image.self) {
-                        await send(.updateSelectedImage(image: image))
+                    if let data = try? await photoItem.loadTransferable(type: Data.self),
+                       let uiImage = UIImage(data: data)?.fixedOrientation() {
+                        await send(.updateSelectedImage(image: uiImage))
                     }
                 }
 
@@ -62,7 +63,7 @@ struct WelcomeStore {
                 return .none
 
             case let .updateSelectedImage(image):
-                state.selectedImage = image
+                state.selectedUIImage = image
                 // TODO: 사진 api 호출
                 return .none
 

--- a/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeStore.swift
@@ -39,6 +39,7 @@ struct WelcomeStore {
     }
 
     @Dependency(\.memberAPIClient) var memberAPIClient
+    @Dependency(\.userProfileStorage) var userProfileStorage
 
     var body: some Reducer<State, Action> {
         BindingReducer()
@@ -59,7 +60,11 @@ struct WelcomeStore {
                 return .send(.getMyProfile)
 
             case .goToHomeButtonTapped:
-                return .none
+                guard let profile = state.myProfile else { return .none }
+
+                return .run { _ in // 기기에 정보 저장
+                    try await userProfileStorage.save(profile)
+                }
 
             case .getMyProfile:
                 return .run { send in

--- a/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeView.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeView.swift
@@ -54,8 +54,8 @@ struct WelcomeView: View {
     private var detailInfoView: some View {
         VStack(spacing: 0) {
             Group {
-                if let image = store.selectedImage {
-                    image
+                if let uiImage = store.selectedUIImage {
+                    Image(uiImage: uiImage)
                         .resizable()
                         .scaledToFill()
                 } else {

--- a/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeView.swift
+++ b/PeepIt/PeepIt/Features/SignUp/Welcome/WelcomeView.swift
@@ -54,10 +54,16 @@ struct WelcomeView: View {
     private var detailInfoView: some View {
         VStack(spacing: 0) {
             Group {
-                if let uiImage = store.selectedUIImage {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .scaledToFill()
+                if let str = store.myProfile?.profile,
+                   let url = URL(string: str) {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+
+                    } placeholder: {
+                        ProgressView()
+                    }
                 } else {
                     Image("ProfileSample")
                         .resizable()

--- a/PeepIt/PeepIt/Models/UserProfile.swift
+++ b/PeepIt/PeepIt/Models/UserProfile.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserProfile: Equatable {
+struct UserProfile: Equatable, Codable {
     var id: String
     var name: String
     var town: String?

--- a/PeepIt/PeepIt/Network/Base/API/APIFetcher.swift
+++ b/PeepIt/PeepIt/Network/Base/API/APIFetcher.swift
@@ -108,6 +108,27 @@ extension APIFetcher {
                 encoding: URLEncoding.queryString,
                 headers: endpoint.header
             )
+
+        case let .requestWithMultipartFormData(formData):
+            return AF.upload(
+                 multipartFormData: { multipart in
+                     for part in formData {
+                         if let filename = part.filename, let mimeType = part.mimeType {
+                             multipart.append(
+                                part.data,
+                                withName: part.name,
+                                fileName: filename,
+                                mimeType: mimeType
+                             )
+                         } else {
+                             multipart.append(part.data, withName: part.name)
+                         }
+                     }
+                 },
+                 to: url,
+                 method: endpoint.method,
+                 headers: endpoint.header
+             )
         }
     }
 }

--- a/PeepIt/PeepIt/Network/Base/API/APITask.swift
+++ b/PeepIt/PeepIt/Network/Base/API/APITask.swift
@@ -17,4 +17,6 @@ enum APITask {
     case requestParameters(parameters: Parameters)
     /// Interceptor를 포함하지 않는 request
     case requestWithoutInterceptor(parameters: Parameters)
+    /// multipart/form-data 요청
+    case requestWithMultipartFormData(formData: [MultipartFormDataPart])
 }

--- a/PeepIt/PeepIt/Network/Base/Core/MultipartFormDataPart.swift
+++ b/PeepIt/PeepIt/Network/Base/Core/MultipartFormDataPart.swift
@@ -1,0 +1,15 @@
+//
+//  MultipartFormDataPart.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import Foundation
+
+struct MultipartFormDataPart {
+    let name: String
+    let data: Data
+    let filename: String?
+    let mimeType: String?
+}

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
@@ -11,6 +11,7 @@ import Alamofire
 enum MemberAPI {
     case getMemberDetail
     case signUp(SignUpDto, String)
+    case patchUserProfileImage(ProfileImgRequestDto)
 }
 
 extension MemberAPI: APIType {
@@ -21,6 +22,8 @@ extension MemberAPI: APIType {
             return "/v1/member/detail"
         case .signUp:
             return "/v1/member/sign-up"
+        case .patchUserProfileImage:
+            return "/v1/member/profile-img"
         }
     }
     
@@ -30,6 +33,8 @@ extension MemberAPI: APIType {
             return .get
         case .signUp:
             return .post
+        case .patchUserProfileImage:
+            return .patch
         }
     }
     
@@ -37,8 +42,23 @@ extension MemberAPI: APIType {
         switch self {
         case .getMemberDetail:
             return .requestPlain
+
         case let .signUp(requestDto, _):
             return .requestJSONEncodable(body: requestDto)
+
+        case let .patchUserProfileImage(requestDto):
+            var parts: [MultipartFormDataPart] = []
+
+            let part = MultipartFormDataPart(
+                name: "profileImg",
+                data: requestDto.profileImg,
+                filename: "profile.jpg",
+                mimeType: "image/jpeg"
+            )
+
+            parts.append(part)
+
+            return .requestWithMultipartFormData(formData: parts)
         }
     }
 

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 struct MemberAPIClient {
     var getMemberDetail: () async throws -> UserProfile
     var signUp: (UserInfo, String) async throws -> Token
+    var modifyUserProfileImage: (Data) async throws -> String
 }
 
 extension MemberAPIClient: DependencyKey {
@@ -33,6 +34,12 @@ extension MemberAPIClient: DependencyKey {
             let requestAPI: MemberAPI = .signUp(requestDto, registerToken)
             let response: LoginResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
             return response.toModel()
+        },
+        modifyUserProfileImage: { data in
+            let requestDto: ProfileImgRequestDto = .init(profileImg: data)
+            let requestAPI: MemberAPI = .patchUserProfileImage(requestDto)
+            let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
+            return response.profile
         }
     )
 }

--- a/PeepIt/PeepIt/Network/Memeber/Dto/Request/ProfileImgRequestDto.swift
+++ b/PeepIt/PeepIt/Network/Memeber/Dto/Request/ProfileImgRequestDto.swift
@@ -1,0 +1,12 @@
+//
+//  ProfileImgRequestDto.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import Foundation
+
+struct ProfileImgRequestDto: Encodable {
+    let profileImg: Data
+}

--- a/PeepIt/PeepIt/Network/Memeber/Dto/Response/MemberDetailResponseDto.swift
+++ b/PeepIt/PeepIt/Network/Memeber/Dto/Response/MemberDetailResponseDto.swift
@@ -24,7 +24,7 @@ extension MemberDetailResponseDto {
             id: id,
             name: name,
             town: town,
-            profile: "",
+            profile: profile,
             gender: GenderType(type: gender),
             isCertificated: role == "CERTIFICATED"
         )

--- a/PeepIt/PeepIt/Utils/Extension/UIImage+Extension.swift
+++ b/PeepIt/PeepIt/Utils/Extension/UIImage+Extension.swift
@@ -1,0 +1,23 @@
+//
+//  UIImage+Extension.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    func fixedOrientation() -> UIImage {
+        if imageOrientation == .up {
+            return self
+        }
+
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalizedImage ?? self
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#165 

## 작업 요약
프로필 이미지 api 연결

## 작업 내용
- 프로필 이미지 api 연결(웰컴뷰, 프로필뷰)
- 프로필 변경 시 기기에 저장 (`userProfileStorage` 디펜던시 활용)
- 홈뷰에서 기기 내 저장된 프로필 보여주기