### PR TITLE
[#167] 사용자 정보 수정

### DIFF
--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		AB33403B2DAE2624007C31FC /* ProfileImgRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */; };
 		AB33403D2DAE2E4A007C31FC /* UserProfileStorageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */; };
 		AB3340442DAE34E4007C31FC /* AsyncProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340432DAE34E4007C31FC /* AsyncProfile.swift */; };
+		AB3340462DAE3ED2007C31FC /* ModifyProfileRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3340452DAE3EC6007C31FC /* ModifyProfileRequestDto.swift */; };
 		AB33888A2D9EA87400316D4B /* CodeCheckRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */; };
 		AB33888D2DA02D6E00316D4B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888C2DA02D6B00316D4B /* MapView.swift */; };
 		AB33888F2DA2DBFF00316D4B /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB33888E2DA2DBFF00316D4B /* LoginRequestDto.swift */; };
@@ -276,6 +277,7 @@
 		AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImgRequestDto.swift; sourceTree = "<group>"; };
 		AB33403C2DAE2E43007C31FC /* UserProfileStorageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileStorageClient.swift; sourceTree = "<group>"; };
 		AB3340432DAE34E4007C31FC /* AsyncProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncProfile.swift; sourceTree = "<group>"; };
+		AB3340452DAE3EC6007C31FC /* ModifyProfileRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyProfileRequestDto.swift; sourceTree = "<group>"; };
 		AB3388862D9C606500316D4B /* PeepIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PeepIt.entitlements; sourceTree = "<group>"; };
 		AB3388892D9EA87400316D4B /* CodeCheckRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCheckRequestDto.swift; sourceTree = "<group>"; };
 		AB33888C2DA02D6B00316D4B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 		AB3340392DAE2615007C31FC /* Request */ = {
 			isa = PBXGroup;
 			children = (
+				AB3340452DAE3EC6007C31FC /* ModifyProfileRequestDto.swift */,
 				AB33403A2DAE261E007C31FC /* ProfileImgRequestDto.swift */,
 			);
 			path = Request;
@@ -1619,6 +1622,7 @@
 				AB416D2F2CF5B6610065BD09 /* RoundedCorner.swift in Sources */,
 				ABC305CC2C932341003B00FE /* HomeView.swift in Sources */,
 				ABD631C62C97602500AFF299 /* ChatView.swift in Sources */,
+				AB3340462DAE3ED2007C31FC /* ModifyProfileRequestDto.swift in Sources */,
 				AB23E3022D39406D003660F8 /* OriginalChatBubbleView.swift in Sources */,
 				AB5159832CAAFCA40043AA0A /* LoginType.swift in Sources */,
 				AB4BEE042D96813500CA3936 /* AuthAPIClient.swift in Sources */,

--- a/PeepIt/PeepIt/Components/Views/CheckEnterFieldStore.swift
+++ b/PeepIt/PeepIt/Components/Views/CheckEnterFieldStore.swift
@@ -52,7 +52,7 @@ struct CheckEnterFieldStore {
     @ObservableState
     struct State: Equatable {
         var text = ""
-        var message = "가이드 문구"
+        var message = " "
         var enterState = EnterState.base
         var fieldType = FieldType.id
 

--- a/PeepIt/PeepIt/Features/Profile/Modify/Gender/ModifyGenderView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/Gender/ModifyGenderView.swift
@@ -85,7 +85,7 @@ struct ModifyGenderView: View {
 
     private var saveButton: some View {
         Button {
-            store.send(.saveButtonTapped)
+            store.send(.genderSaveButtonTapped)
         } label: {
             Text("저장")
                 .mainButtonStyle()

--- a/PeepIt/PeepIt/Features/Profile/Modify/Nickname/NicknameModifyView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/Nickname/NicknameModifyView.swift
@@ -51,7 +51,7 @@ struct NicknameModifyView: View {
 
     private var saveButton: some View {
         Button {
-            store.send(.saveButtonTapped)
+            store.send(.nicknameSaveButtonTapped)
         } label: {
             Text("저장")
                 .mainButtonStyle()

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
@@ -56,6 +56,7 @@ struct ProfileModifyStore {
         case fetchModifyMyProfileImgResponse(Result<String, Error>)
 
         // 프로필 수정 api
+        case modifyNickname(newName: String)
         case modifyGender(newGender: GenderType)
         case fetchModifyProfileResponse(Result<UserProfile, Error>)
     }
@@ -101,6 +102,7 @@ struct ProfileModifyStore {
                 state.nicknameValidation = validateNickname(state.enterFieldState.text)
                 state.enterFieldState.enterState = state.nicknameValidation.enterState
                 state.enterFieldState.message = state.nicknameValidation.message
+                state.nickname = state.enterFieldState.text
 
                 return .none
 
@@ -121,7 +123,8 @@ struct ProfileModifyStore {
                 return .send(.modifyGender(newGender: newGender))
 
             case .nicknameSaveButtonTapped:
-                return .none
+                let newNickname = state.nickname
+                return .send(.modifyNickname(newName: newNickname))
 
             case .dismiss:
                 return .run { _ in await self.dismiss() }
@@ -166,6 +169,19 @@ struct ProfileModifyStore {
                 }
 
                 return .none
+
+            case let .modifyNickname(nickname):
+                var newProfile = state.userProfile
+                newProfile?.name = nickname
+                guard let profile = newProfile else { return .none }
+
+                return .run { send in
+                    await send(
+                        .fetchModifyProfileResponse(
+                            Result { try await memberAPIClient.modifyUserProfile(profile) }
+                        )
+                    )
+                }
 
             case let .modifyGender(newGender):
                 var newProfile = state.userProfile

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
@@ -38,8 +38,10 @@ struct ProfileModifyStore {
         case onAppear
         /// 이전 버튼 탭
         case backButtonTapped
-        /// 저장 버튼 탭
-        case saveButtonTapped
+        /// 성별 수정 버튼 탭
+        case genderSaveButtonTapped
+        /// 닉네임 수정 버튼 탭
+        case nicknameSaveButtonTapped
         /// 성별 선택 시
         case selectGender(GenderType)
         /// 뷰 닫기
@@ -60,6 +62,7 @@ struct ProfileModifyStore {
 
     @Dependency(\.dismiss) var dismiss
     @Dependency(\.userProfileStorage) var userProfileStorage
+    @Dependency(\.authAPIClient) var authAPIClient
     @Dependency(\.memberAPIClient) var memberAPIClient
 
     var body: some Reducer<State, Action> {
@@ -113,9 +116,12 @@ struct ProfileModifyStore {
 
                 return .none
 
-            case .saveButtonTapped:
+            case .genderSaveButtonTapped:
                 guard let newGender = state.selectedGender else { return .none }
                 return .send(.modifyGender(newGender: newGender))
+
+            case .nicknameSaveButtonTapped:
+                return .none
 
             case .dismiss:
                 return .run { _ in await self.dismiss() }

--- a/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Modify/ProfileModify/ProfileModifyStore.swift
@@ -52,6 +52,10 @@ struct ProfileModifyStore {
         /// 프로필 이미지 수정 api
         case modifyMyProfileImg(data: Data)
         case fetchModifyMyProfileImgResponse(Result<String, Error>)
+
+        // 프로필 수정 api
+        case modifyGender(newGender: GenderType)
+        case fetchModifyProfileResponse(Result<UserProfile, Error>)
     }
 
     @Dependency(\.dismiss) var dismiss
@@ -110,7 +114,8 @@ struct ProfileModifyStore {
                 return .none
 
             case .saveButtonTapped:
-                return .send(.dismiss)
+                guard let newGender = state.selectedGender else { return .none }
+                return .send(.modifyGender(newGender: newGender))
 
             case .dismiss:
                 return .run { _ in await self.dismiss() }
@@ -155,6 +160,33 @@ struct ProfileModifyStore {
                 }
 
                 return .none
+
+            case let .modifyGender(newGender):
+                var newProfile = state.userProfile
+                newProfile?.gender = newGender
+                guard let profile = newProfile else { return .none }
+
+                return .run { send in
+                    await send(
+                        .fetchModifyProfileResponse(
+                            Result { try await memberAPIClient.modifyUserProfile(profile) }
+                        )
+                    )
+                }
+
+            case let .fetchModifyProfileResponse(result):
+                switch result {
+
+                case let .success(value):
+                    return .run { send in
+                        try await userProfileStorage.save(value)
+                        await send(.dismiss)
+                    }
+
+                case .failure:
+                    // TODO: 에러 처리
+                    return .none
+                }
 
             default:
                 return .none

--- a/PeepIt/PeepIt/Models/UserProfile.swift
+++ b/PeepIt/PeepIt/Models/UserProfile.swift
@@ -14,4 +14,5 @@ struct UserProfile: Equatable, Codable {
     var profile: String
     var gender: GenderType
     var isCertificated: Bool
+    var isAgree: Bool
 }

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
@@ -12,6 +12,7 @@ enum MemberAPI {
     case getMemberDetail
     case signUp(SignUpDto, String)
     case patchUserProfileImage(ProfileImgRequestDto)
+    case patchUserProfile(ModifyProfileRequestDto)
 }
 
 extension MemberAPI: APIType {
@@ -24,6 +25,8 @@ extension MemberAPI: APIType {
             return "/v1/member/sign-up"
         case .patchUserProfileImage:
             return "/v1/member/profile-img"
+        case .patchUserProfile:
+            return "/v1/member/detail"
         }
     }
     
@@ -33,7 +36,7 @@ extension MemberAPI: APIType {
             return .get
         case .signUp:
             return .post
-        case .patchUserProfileImage:
+        case .patchUserProfileImage, .patchUserProfile:
             return .patch
         }
     }
@@ -59,6 +62,9 @@ extension MemberAPI: APIType {
             parts.append(part)
 
             return .requestWithMultipartFormData(formData: parts)
+
+        case let .patchUserProfile(requestDto):
+            return .requestJSONEncodable(body: requestDto)
         }
     }
 

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
@@ -12,6 +12,7 @@ struct MemberAPIClient {
     var getMemberDetail: () async throws -> UserProfile
     var signUp: (UserInfo, String) async throws -> Token
     var modifyUserProfileImage: (Data) async throws -> String
+    var modifyUserProfle: (UserProfile) async throws -> UserProfile
 }
 
 extension MemberAPIClient: DependencyKey {
@@ -40,6 +41,17 @@ extension MemberAPIClient: DependencyKey {
             let requestAPI: MemberAPI = .patchUserProfileImage(requestDto)
             let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
             return response.profile
+        },
+        modifyUserProfle: { profile in
+            let requestDto: ModifyProfileRequestDto = .init(
+                nickname: profile.name,
+                birth: "", // TODO:
+                gender: profile.gender.type,
+                isAgree: profile.isAgree
+            )
+            let requestAPI: MemberAPI = .patchUserProfile(requestDto)
+            let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
+            return response.toModel()
         }
     )
 }

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
@@ -12,7 +12,7 @@ struct MemberAPIClient {
     var getMemberDetail: () async throws -> UserProfile
     var signUp: (UserInfo, String) async throws -> Token
     var modifyUserProfileImage: (Data) async throws -> String
-    var modifyUserProfle: (UserProfile) async throws -> UserProfile
+    var modifyUserProfile: (UserProfile) async throws -> UserProfile
 }
 
 extension MemberAPIClient: DependencyKey {
@@ -42,7 +42,7 @@ extension MemberAPIClient: DependencyKey {
             let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
             return response.profile
         },
-        modifyUserProfle: { profile in
+        modifyUserProfile: { profile in
             let requestDto: ModifyProfileRequestDto = .init(
                 nickname: profile.name,
                 birth: "", // TODO:

--- a/PeepIt/PeepIt/Network/Memeber/Dto/Request/ModifyProfileRequestDto.swift
+++ b/PeepIt/PeepIt/Network/Memeber/Dto/Request/ModifyProfileRequestDto.swift
@@ -1,0 +1,15 @@
+//
+//  ModifyProfileRequestDto.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/15/25.
+//
+
+import Foundation
+
+struct ModifyProfileRequestDto: Encodable {
+    var nickname: String
+    var birth: String
+    var gender: String
+    var isAgree: Bool
+}

--- a/PeepIt/PeepIt/Network/Memeber/Dto/Response/MemberDetailResponseDto.swift
+++ b/PeepIt/PeepIt/Network/Memeber/Dto/Response/MemberDetailResponseDto.swift
@@ -14,7 +14,7 @@ struct MemberDetailResponseDto: Decodable {
     let town: String
     let gender: String
     let profile: String
-    let isAgree: Bool?
+    let isAgree: Bool
 }
 
 extension MemberDetailResponseDto {
@@ -26,7 +26,8 @@ extension MemberDetailResponseDto {
             town: town,
             profile: profile,
             gender: GenderType(type: gender),
-            isCertificated: role == "CERTIFICATED"
+            isCertificated: role == "CERTIFICATED",
+            isAgree: isAgree
         )
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#167 

## 작업 요약
사용자 정보 수정

## 작업 내용
- 성별, 닉네임 수정 api
- 성공 시 응답으로 온 새로운 프로필 정보로 기기 정보 갱신

## 비고
- 닉네임 작성 시 텍필 때문에 뷰 로딩이 늦음 -> 새로 이슈 파서 해결 예정