### PR TITLE
[#188] 개별 핍 호출 로직

### DIFF
--- a/PeepIt/PeepIt.xcodeproj/project.pbxproj
+++ b/PeepIt/PeepIt.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		ABC793C02DB76D41001B3FE6 /* CurrentAddressRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC793BF2DB76D3A001B3FE6 /* CurrentAddressRequestDto.swift */; };
 		ABC793C22DB76D9D001B3FE6 /* CurrentAddressResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC793C12DB76D98001B3FE6 /* CurrentAddressResponseDto.swift */; };
 		ABC793C42DB76E3E001B3FE6 /* CurrentLocationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC793C32DB76E39001B3FE6 /* CurrentLocationInfo.swift */; };
+		ABCBE97B2DBE424C00CAF83F /* AsyncStoryImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCBE97A2DBE423B00CAF83F /* AsyncStoryImage.swift */; };
 		ABCC50E12CEF8F23004AD297 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCC50E02CEF8F23004AD297 /* BackButton.swift */; };
 		ABCC50E52CEF90FF004AD297 /* GuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCC50E42CEF90FF004AD297 /* GuideView.swift */; };
 		ABCC50E72CEF910D004AD297 /* GuideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCC50E62CEF9105004AD297 /* GuideStore.swift */; };
@@ -419,6 +420,7 @@
 		ABC793BF2DB76D3A001B3FE6 /* CurrentAddressRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAddressRequestDto.swift; sourceTree = "<group>"; };
 		ABC793C12DB76D98001B3FE6 /* CurrentAddressResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAddressResponseDto.swift; sourceTree = "<group>"; };
 		ABC793C32DB76E39001B3FE6 /* CurrentLocationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentLocationInfo.swift; sourceTree = "<group>"; };
+		ABCBE97A2DBE423B00CAF83F /* AsyncStoryImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStoryImage.swift; sourceTree = "<group>"; };
 		ABCC50E02CEF8F23004AD297 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		ABCC50E42CEF90FF004AD297 /* GuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideView.swift; sourceTree = "<group>"; };
 		ABCC50E62CEF9105004AD297 /* GuideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideStore.swift; sourceTree = "<group>"; };
@@ -1347,6 +1349,7 @@
 		ABCCB6DE2DB1216F00A226C4 /* Loading */ = {
 			isa = PBXGroup;
 			children = (
+				ABCBE97A2DBE423B00CAF83F /* AsyncStoryImage.swift */,
 				ABC793B42DB12D2D001B3FE6 /* AsyncThumbnail.swift */,
 				AB3340432DAE34E4007C31FC /* AsyncProfile.swift */,
 			);
@@ -1829,6 +1832,7 @@
 				AB3340252DA4FB0C007C31FC /* LegalCodeRequestDto.swift in Sources */,
 				ABC171FC2CAB1A0800370901 /* AuthenticationStore.swift in Sources */,
 				AB33402B2DA4FBC6007C31FC /* Location.swift in Sources */,
+				ABCBE97B2DBE424C00CAF83F /* AsyncStoryImage.swift in Sources */,
 				ABD3CAB72CA1BF2F00438747 /* OtherProfileView.swift in Sources */,
 				AB3340342DAD701B007C31FC /* MapInteractionState.swift in Sources */,
 				ABCC50E12CEF8F23004AD297 /* BackButton.swift in Sources */,

--- a/PeepIt/PeepIt/DesignSystem/UseCase/Loading/AsyncStoryImage.swift
+++ b/PeepIt/PeepIt/DesignSystem/UseCase/Loading/AsyncStoryImage.swift
@@ -1,0 +1,49 @@
+//
+//  AsyncStoryImage.swift
+//  PeepIt
+//
+//  Created by 김민 on 4/27/25.
+//
+
+import SwiftUI
+
+struct AsyncStoryImage: View {
+    let dataURLStr: String?
+    let isVideo: Bool
+
+    private var url: URL? {
+        guard let str = dataURLStr else { return nil }
+        return URL(string: str)
+    }
+
+    var body: some View {
+        Group {
+            if let url = url {
+                if isVideo {
+                    LoopingVideoPlayerView(
+                        videoURL: url,
+                        isSoundOn: false,
+                        isPlaying: true
+                    )
+                    .frame(width: Constant.screenWidth, height: Constant.screenWidth * 16/9)
+                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                } else {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(9/16, contentMode: .fit)
+                            .frame(width: Constant.screenWidth)
+                            .clipShape(RoundedRectangle(cornerRadius: 24))
+                        
+                    } placeholder: {
+                        Color.base
+                    }
+                }
+            } else {
+                Color.base
+                    .aspectRatio(9/16, contentMode: .fit)
+                    .frame(width: Constant.screenWidth)
+            }
+        }
+    }
+}

--- a/PeepIt/PeepIt/DesignSystem/UseCase/Loading/AsyncStoryImage.swift
+++ b/PeepIt/PeepIt/DesignSystem/UseCase/Loading/AsyncStoryImage.swift
@@ -22,7 +22,7 @@ struct AsyncStoryImage: View {
                 if isVideo {
                     LoopingVideoPlayerView(
                         videoURL: url,
-                        isSoundOn: false,
+                        isSoundOn: true,
                         isPlaying: true
                     )
                     .frame(width: Constant.screenWidth, height: Constant.screenWidth * 16/9)

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
@@ -57,6 +57,9 @@ struct PeepDetailStore {
             case townPeep
             case others
         }
+
+        var peepIdList: [Int] = .init()
+        var peeps: [[Int: Peep]] = .init()
     }
 
     enum Action: BindableAction {
@@ -128,7 +131,7 @@ struct PeepDetailStore {
                 return .none
 
             case .onAppear:
-                return .send(.setReaction)
+                return .none
 
             case .setReaction:
                 guard let reactionStr = state.peepList[state.currentIdx].reaction else {

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
@@ -60,6 +60,7 @@ struct PeepDetailStore {
 
         var peepIdList: [Int] = []
         var peeps: [Peep?] = []
+        var topLocations: [String?] = []
     }
 
     enum Action: BindableAction {
@@ -139,6 +140,7 @@ struct PeepDetailStore {
 
             case .onAppear:
                 state.peeps = Array(repeating: nil, count: state.peepIdList.count)
+                state.topLocations = Array(repeating: nil, count: state.peepIdList.count)
 
                 return .merge(
                     .send(.getPeepDetail(id: state.peepIdList[state.currentIdx])),
@@ -272,6 +274,7 @@ struct PeepDetailStore {
                 case let .success(peep):
                     if let index = state.peepIdList.firstIndex(of: peep.id) {
                         state.peeps[index] = peep
+                        state.topLocations[index] = peep.buildingName
                     }
 
                 case let .failure(error):

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailStore.swift
@@ -99,12 +99,17 @@ struct PeepDetailStore {
         case setTimer
         case timerTicked
         case stopTimer
+
+        /// 개별 핍 api
+        case getPeepDetail(id: Int)
+        case fetchPeepDetailResponse(Result<Peep, Error>)
     }
 
     enum CancelId {
         case timer
     }
 
+    @Dependency(\.peepAPIClient) var peepAPIClient
     @Dependency(\.dismiss) var dismiss
 
     var body: some Reducer<State, Action> {
@@ -232,6 +237,27 @@ struct PeepDetailStore {
 
             case .shareButtonTapped:
                 state.showShareSheet.toggle()
+                return .none
+
+            case let .getPeepDetail(id):
+                return .run { send in
+                    await send(
+                        .fetchPeepDetailResponse(
+                            Result { try await peepAPIClient.fetchPeepDetail(id) }
+                        )
+                    )
+                }
+
+            case let .fetchPeepDetailResponse(result):
+                switch result {
+
+                case let .success(peep):
+                    print(peep)
+
+                case let .failure(error):
+                    print(error)
+                }
+
                 return .none
 
             default:

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -31,8 +31,7 @@ struct PeepDetailView: View {
                                 ), id: \.0) { idx, id in
                                 WithPerceptionTracking {
                                     ZStack {
-                                        if let peep = store.peeps[safe: idx],
-                                            let peepContent = peep {
+                                        if let peepContent = store.peepCache[idx] {
                                             /// 뒷 배경 사진 레이아웃
                                             VStack(spacing: 11) {
                                                 Spacer().frame(height: 44)
@@ -182,7 +181,7 @@ extension PeepDetailView {
                 .resizable()
                 .frame(width: 22.4, height: 22.4)
 
-            Text((store.topLocations[safe: store.currentIdx] ?? "") ?? "")
+            Text(store.peepLocation[store.currentIdx] ?? "")
                 .pretendard(.body02)
         }
         .padding(.leading, 15)

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -31,43 +31,47 @@ struct PeepDetailView: View {
                                 ), id: \.0) { idx, id in
                                 WithPerceptionTracking {
                                     ZStack {
-                                        BackImageLayer.secondary()
-                                            .ignoresSafeArea()
-                                            .allowsHitTesting(false)
+                                        if let peep = store.peeps[safe: idx],
+                                            let peepContent = peep {
+                                            /// 뒷 배경 사진 레이아웃
+                                            VStack(spacing: 11) {
+                                                Spacer().frame(height: 44)
 
-                                        Text("\(id)")
+                                                AsyncStoryImage(
+                                                    dataURLStr: peepContent.data,
+                                                    isVideo: peepContent.isVideo
+                                                )
+                                                .highPriorityGesture(
+                                                    TapGesture()
+                                                        .onEnded { store.send(.viewTapped) }
+                                                )
+
+                                                Spacer()
+                                            }
+                                            .ignoresSafeArea(.all, edges: .bottom)
+
+                                            BackImageLayer.secondary()
+                                                .ignoresSafeArea()
+                                                .allowsHitTesting(false)
+
+                                            /// 진입 애니메이션 처리 여부
+                                            if store.showPeepDetailObject {
+                                                /// 앞 오브젝트
+                                                VStack {
+                                                    Spacer()
+                                                    detailView(peep: peepContent)
+                                                        .padding(.horizontal, 16)
+                                                        .padding(.bottom, 84)
+                                                }
+                                                .ignoresSafeArea()
+                                            }
+
+                                        } else {
+                                            Color.base
+                                                .ignoresSafeArea()
+                                        }
                                     }
-//                                    ZStack {
-//                                        /// 뒷 배경 사진 레이아웃
-//                                        VStack(spacing: 11) {
-//                                            Spacer().frame(height: 44)
-//
-//                                            peepView
-//                                                .highPriorityGesture(
-//                                                    TapGesture()
-//                                                        .onEnded {store.send(.viewTapped) }
-//                                                )
-//
-//                                            Spacer()
-//                                        }
-//                                        .ignoresSafeArea(.all, edges: .bottom)
-//
-//                                        BackImageLayer.secondary()
-//                                            .ignoresSafeArea()
-//                                            .allowsHitTesting(false)
-//
-//                                        if store.showPeepDetailObject {
-//                                            /// 앞 오브젝트
-//                                            VStack {
-//                                                Spacer()
-//                                                detailView(peep: peep)
-//                                                    .padding(.horizontal, 16)
-//                                                    .padding(.bottom, 84)
-//                                            }
-//                                            .ignoresSafeArea()
-//                                        }
-//                                    }
-//                                    .tag(idx)
+                                    .tag(idx)
                                 }
                             }
                         }
@@ -236,15 +240,6 @@ extension PeepDetailView {
             .pretendard(.body02)
             .foregroundStyle(Color.coreRed)
         }
-    }
-
-    /// TODO: 이미지로 수정
-    private var peepView: some View {
-        Image("SampleImage")
-            .resizable()
-            .aspectRatio(9/16, contentMode: .fit)
-            .frame(width: Constant.screenWidth)
-            .clipShape(RoundedRectangle(cornerRadius: 24))
     }
 
     private func detailView(peep: Peep) -> some View {

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -88,10 +88,6 @@ struct PeepDetailView: View {
                     .ignoresSafeArea(.all, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
                     .onAppear { store.send(.onAppear) }
-//                    .highPriorityGesture(
-//                        TapGesture()
-//                            .onEnded {store.send(.viewTapped) }
-//                    )
                     .overlay(alignment: .topTrailing) {
                         /// 상단 우측 더보기 메뉴
                         if store.state.showElseMenu {
@@ -186,7 +182,7 @@ extension PeepDetailView {
                 .resizable()
                 .frame(width: 22.4, height: 22.4)
 
-            Text("동이름, 건물 이름")
+            Text((store.topLocations[safe: store.currentIdx] ?? "") ?? "")
                 .pretendard(.body02)
         }
         .padding(.leading, 15)
@@ -249,12 +245,14 @@ extension PeepDetailView {
                     state: RootStore.Path.State.otherProfile(OtherProfileStore.State())
                 ) {
                     HStack {
-                        Image("ProfileSample")
-                            .resizable()
+                        AsyncProfile(profileUrlStr: peep.profileUrl)
                             .frame(width: 37.62, height: 37.62)
-                        Text("hyerim")
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                        Text(peep.writerId)
                             .pretendard(.headline)
-                        Text("3분 전")
+
+                        Text(peep.uploadAt)
                             .pretendard(.caption04)
 
                         Spacer()

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailView.swift
@@ -26,41 +26,48 @@ struct PeepDetailView: View {
                         TabView(selection: $store.currentIdx) {
                             ForEach(
                                 Array(
-                                    zip(store.peepList.indices,
-                                        store.peepList)
-                                ), id: \.0) { idx, peep in
+                                    zip(store.peepIdList.indices,
+                                        store.peepIdList)
+                                ), id: \.0) { idx, id in
                                 WithPerceptionTracking {
                                     ZStack {
-                                        /// 뒷 배경 사진 레이아웃
-                                        VStack(spacing: 11) {
-                                            Spacer().frame(height: 44)
-
-                                            peepView
-                                                .highPriorityGesture(
-                                                    TapGesture()
-                                                        .onEnded {store.send(.viewTapped) }
-                                                )
-
-                                            Spacer()
-                                        }
-                                        .ignoresSafeArea(.all, edges: .bottom)
-
                                         BackImageLayer.secondary()
                                             .ignoresSafeArea()
                                             .allowsHitTesting(false)
 
-                                        if store.showPeepDetailObject {
-                                            /// 앞 오브젝트
-                                            VStack {
-                                                Spacer()
-                                                detailView(peep: peep)
-                                                    .padding(.horizontal, 16)
-                                                    .padding(.bottom, 84)
-                                            }
-                                            .ignoresSafeArea()
-                                        }
+                                        Text("\(id)")
                                     }
-                                    .tag(idx)
+//                                    ZStack {
+//                                        /// 뒷 배경 사진 레이아웃
+//                                        VStack(spacing: 11) {
+//                                            Spacer().frame(height: 44)
+//
+//                                            peepView
+//                                                .highPriorityGesture(
+//                                                    TapGesture()
+//                                                        .onEnded {store.send(.viewTapped) }
+//                                                )
+//
+//                                            Spacer()
+//                                        }
+//                                        .ignoresSafeArea(.all, edges: .bottom)
+//
+//                                        BackImageLayer.secondary()
+//                                            .ignoresSafeArea()
+//                                            .allowsHitTesting(false)
+//
+//                                        if store.showPeepDetailObject {
+//                                            /// 앞 오브젝트
+//                                            VStack {
+//                                                Spacer()
+//                                                detailView(peep: peep)
+//                                                    .padding(.horizontal, 16)
+//                                                    .padding(.bottom, 84)
+//                                            }
+//                                            .ignoresSafeArea()
+//                                        }
+//                                    }
+//                                    .tag(idx)
                                 }
                             }
                         }

--- a/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewThumbnail.swift
+++ b/PeepIt/PeepIt/Features/PeepPreview/PeepPreviewThumbnail.swift
@@ -11,7 +11,7 @@ struct PeepPreviewThumbnail: View {
     let peep: Peep
 
     var body: some View {
-        ZStack(alignment: .leading) {
+        ZStack {
             Group {
                 AsyncThumbnail(imgStr: peep.data)
                 ThumbnailLayer.primary()
@@ -20,7 +20,7 @@ struct PeepPreviewThumbnail: View {
             .frame(width: 281, height: 384)
             .clipShape(RoundedRectangle(cornerRadius: 20))
 
-            VStack(alignment: .leading) {
+            VStack {
                 HStack(spacing: 2) {
                     Image("IconPeep")
                     Text("현재 위치에서 0km") // TODO:
@@ -36,8 +36,7 @@ struct PeepPreviewThumbnail: View {
             }
             .padding(.top, 19)
             .padding(.bottom, 20)
-            .padding(.leading, 16)
-            .frame(width: 250)
+            .padding(.horizontal, 15)
         }
         .frame(width: 281, height: 384)
         .clipShape(RoundedRectangle(cornerRadius: 20))

--- a/PeepIt/PeepIt/Features/Root/RootStore.swift
+++ b/PeepIt/PeepIt/Features/Root/RootStore.swift
@@ -183,14 +183,14 @@ struct RootStore {
                     state.path.removeAll()
                     return .none
 
-                case let .element(_, action: .townPeeps(.peepCellTapped(idx, peeps))):
+                case let .element(_, action: .townPeeps(.peepCellTapped(idx, peepIdList))):
                     state.path.append(
                         .peepDetail(PeepDetailStore.State(
                             entryType: .townPeep,
-                            peepList: peeps,
                             currentIdx: idx,
                             showPeepDetailObject: true,
-                            showPeepDetailBg: true
+                            showPeepDetailBg: true,
+                            peepIdList: peepIdList
                         ))
                     )
                     return .none

--- a/PeepIt/PeepIt/Features/Root/RootStore.swift
+++ b/PeepIt/PeepIt/Features/Root/RootStore.swift
@@ -158,7 +158,7 @@ struct RootStore {
                 case let .element(_, action: .camera(.pushToEdit(image, videoURL))):
                     state.path.append(
                         .edit(EditStore.State(image: image, videoURL: videoURL))
-                    ) 
+                    )
                     return .none
 
                 case let .element(_, action: .edit(.pushToWriteBody(image, videoURL))):
@@ -183,13 +183,15 @@ struct RootStore {
                     state.path.removeAll()
                     return .none
 
-                case let .element(_, action: .townPeeps(.peepCellTapped(idx, peepIdList))):
+                case let .element(_, action: .townPeeps(.peepCellTapped(idx, peepIdList, page, size))):
                     state.path.append(
                         .peepDetail(PeepDetailStore.State(
                             entryType: .townPeep,
                             currentIdx: idx,
                             showPeepDetailObject: true,
                             showPeepDetailBg: true,
+                            size: size,
+                            page: page,
                             peepIdList: peepIdList
                         ))
                     )

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
@@ -19,7 +19,7 @@ struct TownPeepsStore {
         var peeps: [Peep] = []
 
         var page = 0
-        var size = 5
+        var size = 10
         var hasNext = true
 
         var todayStr = ""

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
@@ -24,6 +24,8 @@ struct TownPeepsStore {
 
         var todayStr = ""
         var myTown = ""
+
+        var peepIdList: [Int] = []
     }
 
     enum Action {
@@ -32,7 +34,7 @@ struct TownPeepsStore {
         case refresh
         case refreshEnded
         case onAppear
-        case peepCellTapped(idx: Int, peeps: [Peep])
+        case peepCellTapped(idx: Int, peepIdList: [Int])
         case uploadButtonTapped
 
         /// 내 동네 불러오기
@@ -113,8 +115,10 @@ struct TownPeepsStore {
 
                     if pagedPeeps.page == 0 {
                         state.peeps = pagedPeeps.content
+                        state.peepIdList = pagedPeeps.content.map { $0.id }
                     } else {
                         state.peeps.append(contentsOf: pagedPeeps.content)
+                        state.peepIdList.append(contentsOf: pagedPeeps.content.map { $0.id })
                     }
 
                     state.hasNext = pagedPeeps.hasNext

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsStore.swift
@@ -52,6 +52,7 @@ struct TownPeepsStore {
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+
             case .onAppear:
                 let formatter = DateFormatter()
                 formatter.dateFormat = "M월 d일"
@@ -125,8 +126,9 @@ struct TownPeepsStore {
                     state.page += 1
 
                 case let .failure(error):
-                    // TODO: - 에러 처리
-                    print(error)
+                    guard error.asPeepItError() != .noPeep else { return .none }
+
+                    // TODO: 핍이 없는 경우를 제외한 에러일 때 처리
                 }
 
                 /// 새로고침 중이라면 새로고침 끝내기

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
@@ -168,7 +168,7 @@ struct TownPeepsView: View {
                         ForEach(Array(store.peeps.enumerated()), id: \.element.id) { (idx, peep) in
                             ThumbnailPeep(peep: peep)
                                 .onTapGesture {
-                                    store.send(.peepCellTapped(idx: idx, peeps: store.peeps))
+                                    store.send(.peepCellTapped(idx: idx, peepIdList: store.peepIdList))
                                 }
                                 .onAppear {
                                     if idx == store.peeps.count - 2 && store.hasNext {

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
@@ -168,11 +168,18 @@ struct TownPeepsView: View {
                         ForEach(Array(store.peeps.enumerated()), id: \.element.id) { (idx, peep) in
                             ThumbnailPeep(peep: peep)
                                 .onTapGesture {
-                                    store.send(.peepCellTapped(idx: idx, peepIdList: store.peepIdList))
+                                    store.send(
+                                        .peepCellTapped(
+                                            idx: idx,
+                                            peepIdList: store.peepIdList,
+                                            page: store.page,
+                                            size: store.size
+                                        )
+                                    )
                                 }
                                 .onAppear {
                                     if idx == store.peeps.count - 2 && store.hasNext {
-                                        store.send(.fetchTownPeeps)
+                                        store.send(.fetchTownPeeps(page: store.page+1, size: store.size))
                                     }
                                 }
                         }

--- a/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
+++ b/PeepIt/PeepIt/Features/TownPeeps/TownPeepsView.swift
@@ -158,14 +158,17 @@ struct TownPeepsView: View {
                 }
                 .padding(.bottom, 25)
 
-                if store.peeps.isEmpty {
+                if store.peeps.isEmpty && !store.isRefreshing {
                     emptyView
                 } else {
                     LazyVGrid(
                         columns: [GridItem(.flexible()), GridItem(.flexible())],
                         spacing: 8
                     ) {
-                        ForEach(Array(store.peeps.enumerated()), id: \.element.id) { (idx, peep) in
+                        ForEach(
+                            Array(store.peeps.enumerated()),
+                            id: \.element.id) { (idx, peep
+                        ) in
                             ThumbnailPeep(peep: peep)
                                 .onTapGesture {
                                     store.send(

--- a/PeepIt/PeepIt/Network/Peep/API/PeepAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Peep/API/PeepAPIClient.swift
@@ -26,6 +26,8 @@ struct PeepAPIClient {
     var fetchCurrentLocationInfo: (Coordinate) async throws -> CurrentLocationInfo
     /// 지도 내 핍 조회
     var fetchPeepsInMap: (Coordinate, Int, Int, Int) async throws -> PagedPeeps
+    /// 핍 디테일 조회
+    var fetchPeepDetail: (Int) async throws -> Peep
 }
 
 extension PeepAPIClient: DependencyKey {
@@ -89,6 +91,12 @@ extension PeepAPIClient: DependencyKey {
             )
             let requestAPI = PeepAPI.getMapPeeps(requestDto)
             let response: PagedResponsePeepDto = try await APIFetcher.shared.fetch(of: requestAPI)
+            return response.toModel()
+        },
+        fetchPeepDetail: { peepId in
+            let requestDto: PeepDetailRequestDto = .init(peepId: peepId)
+            let requestAPi = PeepAPI.getPeepDetail(requestDto)
+            let response: CommonPeepDto = try await APIFetcher.shared.fetch(of: requestAPi)
             return response.toModel()
         }
     )

--- a/PeepIt/PeepIt/Network/Peep/API/PeepAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Peep/API/PeepAPIClient.swift
@@ -69,7 +69,8 @@ extension PeepAPIClient: DependencyKey {
                 content: uploadPeep.content,
                 latitude: uploadPeep.y,
                 longitude: uploadPeep.x,
-                building: uploadPeep.building
+                building: uploadPeep.building,
+                isVideo: isVideo
             )
 
             let requestAPI = PeepAPI.postPeep(requestDto, uploadPeep.data, isVideo)

--- a/PeepIt/PeepIt/Network/Peep/Dto/Request/PeepUploadRequestDto.swift
+++ b/PeepIt/PeepIt/Network/Peep/Dto/Request/PeepUploadRequestDto.swift
@@ -16,4 +16,5 @@ struct PeepUploadRequestDto: Encodable {
     let roadNameAddress: String = "주소"
     let roadNameCode: String = "도로번호"
     let building: String
+    let isVideo: Bool
 }

--- a/PeepIt/PeepIt/Network/Peep/Dto/Response/CommonPeepDto.swift
+++ b/PeepIt/PeepIt/Network/Peep/Dto/Response/CommonPeepDto.swift
@@ -23,6 +23,7 @@ struct CommonPeepDto: Codable {
     let stickerNum: Int
     let chatNum: Int
     let popularity: Int
+    let isVideo: Bool
 }
 
 extension CommonPeepDto {
@@ -35,7 +36,7 @@ extension CommonPeepDto {
             writerId: memberId,
             isActive: isActive,
             reaction: nil, // TODO: - stickerNum 순서 파악 필요
-            isVideo: true, // TODO: - isVideo 추가 요청 필요
+            isVideo: isVideo,
             chatNum: chatNum,
             stickerNum: stickerNum,
             buildingName: building,

--- a/PeepIt/PeepIt/Resources/CoreSystem/Overlay/BackImageLayer.swift
+++ b/PeepIt/PeepIt/Resources/CoreSystem/Overlay/BackImageLayer.swift
@@ -52,7 +52,7 @@ extension BackImageLayer {
             ]),
             startPoint: .top,
             endPoint: .bottom,
-            opacity: 0.6
+            opacity: 0.2
         )
     }
 }

--- a/PeepIt/PeepIt/Resources/CoreSystem/Overlay/ThumbnailLayer.swift
+++ b/PeepIt/PeepIt/Resources/CoreSystem/Overlay/ThumbnailLayer.swift
@@ -31,10 +31,10 @@ struct ThumbnailLayer: View {
 extension ThumbnailLayer {
 
     static func primary() -> ThumbnailLayer {
-        return ThumbnailLayer(startPoint: .leading, endPoint: .trailing, opacity: 0.5)
+        return ThumbnailLayer(startPoint: .leading, endPoint: .trailing, opacity: 0.2)
     }
 
     static func secondary() -> ThumbnailLayer {
-        return ThumbnailLayer(startPoint: .top, endPoint: .bottom, opacity: 0.6)
+        return ThumbnailLayer(startPoint: .top, endPoint: .bottom, opacity: 0.2)
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#188 

## 작업 요약
개별 핍 호출, 동네 소식 -> 개별 핍 전환 시 로직

## 작업 내용
- 개별 핍 호출 api 작성
- 인스타그램 스토리와 같이 prefetch(현재 보고 있는 핍 앞뒤의 2개 정도를 호출해서 캐시로 저장하는 로직) 적용
- 동네 소식에서 페이지네이션을 전부 하지 않고 개별 핍에 들어왔을 때, 페이지네이션 api 적용하여 prefetch 처리하도록 구현

## 스크린샷
(*현재까지 적용된 이미지에서는 isVideo 필드 부재로 인해 사진 제대로 뜨지 않음)

https://github.com/user-attachments/assets/ef8abb3f-33dc-4193-affa-6f54ef325269
