### PR TITLE
[#195] 타 유저 프로필 조회 api

### DIFF
--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailList/PeepDetailListStore.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailList/PeepDetailListStore.swift
@@ -87,6 +87,8 @@ struct PeepDetailListStore {
         case shareButtonTapped
         /// 리액션 설정
         case setReaction
+        /// 프로필 탭
+        case profileTapped(id: String)
 
         /// 개별 핍 api
         case getPeepDetail(id: Int)
@@ -298,6 +300,9 @@ struct PeepDetailListStore {
                         await send(.getPeepDetail(id: id))
                     }
                 }
+
+            case .profileTapped:
+                return .none
 
             default:
                 return .none

--- a/PeepIt/PeepIt/Features/PeepDetail/PeepDetailList/PeepDetailListView.swift
+++ b/PeepIt/PeepIt/Features/PeepDetail/PeepDetailList/PeepDetailListView.swift
@@ -224,24 +224,25 @@ extension PeepDetailListView {
     private func detailView(peep: Peep) -> some View {
         HStack(alignment: .bottom, spacing: 12) {
             VStack(spacing: 9) {
-                NavigationLink(
-                    state: RootStore.Path.State.otherProfile(OtherProfileStore.State())
-                ) {
-                    HStack {
-                        AsyncProfile(profileUrlStr: peep.profileUrl)
-                            .frame(width: 37.62, height: 37.62)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                HStack {
+                    AsyncProfile(profileUrlStr: peep.profileUrl)
+                        .frame(width: 37.62, height: 37.62)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
 
-                        Text(peep.writerId)
-                            .pretendard(.headline)
+                    Text(peep.writerId)
+                        .pretendard(.headline)
 
-                        Text(peep.uploadAt)
-                            .pretendard(.caption04)
+                    Text(peep.uploadAt)
+                        .pretendard(.caption04)
 
-                        Spacer()
-                    }
-                    .foregroundStyle(Color.white)
+                    Spacer()
                 }
+                .foregroundStyle(Color.white)
+                .contentShape(Rectangle())
+                .highPriorityGesture(
+                    TapGesture()
+                        .onEnded { store.send(.profileTapped(id: peep.writerId)) }
+                )
 
                 HStack {
                     Text(peep.content.forceCharWrapping)

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
@@ -13,8 +13,11 @@ struct OtherProfileStore {
 
     @ObservableState
     struct State: Equatable {
+        /// 유저 아이디
+        var userId = ""
+
         /// 핍 리스트
-        var uploadedPeeps: [Peep] = [.stubPeep0, .stubPeep1, .stubPeep2, .stubPeep3, .stubPeep4, .stubPeep5, .stubPeep6, .stubPeep7, .stubPeep8, .stubPeep9]
+        var uploadedPeeps: [Peep] = []
         /// 상단 우측 더보기 버튼 탭 여부
         var isElseButtonTapped = false
         /// 유저 차단 여부
@@ -69,6 +72,7 @@ struct OtherProfileStore {
 
             case .onAppear:
                 // TODO: 차단 여부 로드
+                print(state.userId)
                 return .none
 
             case let .elseButtonTapped(newState):

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileStore.swift
@@ -16,6 +16,7 @@ struct OtherProfileStore {
         /// 유저 아이디
         var userId = ""
 
+        var userProfile: UserProfile?
         /// 핍 리스트
         var uploadedPeeps: [Peep] = []
         /// 상단 우측 더보기 버튼 탭 여부
@@ -28,6 +29,7 @@ struct OtherProfileStore {
         var isModalVisible = false
         /// 공유하기 보여주기
         var showShareSheet = false
+        /// 유저 프로필
     }
 
     enum Action: BindableAction {
@@ -58,8 +60,13 @@ struct OtherProfileStore {
         case shareButtonTapped
         /// 핍 셀 선택
         case peepCellTapped(peep: Peep)
+
+        /// 멤버 조회 api
+        case fetchMemberDetail(id: String)
+        case fetchMemberDetailResponse(Result<UserProfile, Error>)
     }
 
+    @Dependency(\.memberAPIClient) var memberAPIClient
     @Dependency(\.dismiss) var dismiss
 
     var body: some Reducer<State, Action> {
@@ -71,9 +78,7 @@ struct OtherProfileStore {
                 return .none
 
             case .onAppear:
-                // TODO: 차단 여부 로드
-                print(state.userId)
-                return .none
+                return .send(.fetchMemberDetail(id: state.userId))
 
             case let .elseButtonTapped(newState):
                 state.isElseButtonTapped = newState
@@ -136,7 +141,28 @@ struct OtherProfileStore {
 
             case .peepCellTapped:
                 return .none
-                
+
+            case let .fetchMemberDetail(id):
+                return .run { send in
+                    await send(
+                        .fetchMemberDetailResponse(
+                            Result { try await memberAPIClient.getOtherMemberDetail(id) }
+                        )
+                    )
+                }
+
+            case let .fetchMemberDetailResponse(result):
+                switch result {
+                case let .success(profile):
+                    state.userProfile = profile
+                    
+                case .failure:
+                    print("실패")
+                }
+
+                return .none
+
+
             default:
                 return .none
             }

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -67,6 +67,7 @@ struct OtherProfileView: View {
                 }
 
                 /// 차단 안내문 모달
+                // TODO: 모달 드래그 로직 이동
                 VStack {
                     Spacer()
                     BlockDescriptionModal(store: self.store)

--- a/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
+++ b/PeepIt/PeepIt/Features/Profile/Others/OtherProfileView.swift
@@ -21,7 +21,7 @@ struct OtherProfileView: View {
 
                     PeepItNavigationBar(
                         leading: backButton,
-                        title: "@아이디",
+                        title: "@\(store.userProfile?.id ?? "")",
                         trailing: elseButton
                     )
                     .padding(.bottom, 43)
@@ -117,21 +117,23 @@ struct OtherProfileView: View {
 
     private var profileView: some View {
         VStack(spacing: 26) {
-            Image("ProfileSample")
-                .resizable()
-                .scaledToFill()
-                .frame(width: 91.2, height: 91.2)
+            AsyncProfile(profileUrlStr: store.userProfile?.profile)
+                .frame(width: 91, height: 91)
+                .clipShape(RoundedRectangle(cornerRadius: 21))
 
             VStack(spacing: 11) {
-                Text("${닉네임}")
+                Text("\(store.userProfile?.name ?? "")")
                     .pretendard(.title02)
 
                 HStack(spacing: 2) {
                     Image("IconLocation")
                         .resizable()
                         .frame(width: 22.4, height: 22.4)
-                    Text("동이름")
-                        .pretendard(.body02)
+                    Text(
+                        store.userProfile?.townInfo?.address.components(separatedBy: " ").last
+                        ?? ""
+                    )
+                    .pretendard(.body02)
                 }
             }
             .padding(.vertical, 7)

--- a/PeepIt/PeepIt/Features/Root/RootStore.swift
+++ b/PeepIt/PeepIt/Features/Root/RootStore.swift
@@ -220,6 +220,10 @@ struct RootStore {
                     )
                     return .none
 
+                case let .element(_, action: .peepDetailList(.profileTapped(id))):
+                    state.path.append(.otherProfile(OtherProfileStore.State(userId: id)))
+                    return .none
+
                 default:
                     return .none
                 }

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPI.swift
@@ -10,6 +10,7 @@ import Alamofire
 
 enum MemberAPI {
     case getMemberDetail
+    case getOtherMemberDetail(String)
     case signUp(SignUpDto, String)
     case patchUserProfileImage(ProfileImgRequestDto)
     case patchUserProfile(ModifyProfileRequestDto)
@@ -21,6 +22,8 @@ extension MemberAPI: APIType {
         switch self {
         case .getMemberDetail:
             return "/v1/member/detail"
+        case let .getOtherMemberDetail(memberId):
+            return "/v1/member/detail/\(memberId)"
         case .signUp:
             return "/v1/member/sign-up"
         case .patchUserProfileImage:
@@ -32,7 +35,7 @@ extension MemberAPI: APIType {
     
     var method: HTTPMethod {
         switch self {
-        case .getMemberDetail:
+        case .getMemberDetail, .getOtherMemberDetail:
             return .get
         case .signUp:
             return .post
@@ -43,8 +46,12 @@ extension MemberAPI: APIType {
     
     var task: APITask {
         switch self {
+            
         case .getMemberDetail:
             return .requestPlain
+
+        case let .getOtherMemberDetail(memberId):
+            return .requestParameters(parameters: memberId.toDictionary())
 
         case let .signUp(requestDto, _):
             return .requestJSONEncodable(body: requestDto)

--- a/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
+++ b/PeepIt/PeepIt/Network/Memeber/API/MemberAPIClient.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 
 struct MemberAPIClient {
     var getMemberDetail: () async throws -> UserProfile
+    var getOtherMemberDetail: (String) async throws -> UserProfile
     var signUp: (UserInfo, String) async throws -> Token
     var modifyUserProfileImage: (Data) async throws -> String
     var modifyUserProfile: (UserProfile) async throws -> UserProfile
@@ -20,6 +21,11 @@ extension MemberAPIClient: DependencyKey {
     static let liveValue: MemberAPIClient = MemberAPIClient(
         getMemberDetail: { 
             let requestAPI: MemberAPI = .getMemberDetail
+            let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
+            return response.toModel()
+        },
+        getOtherMemberDetail: { memberId in
+            let requestAPI: MemberAPI = .getOtherMemberDetail(memberId)
             let response: MemberDetailResponseDto = try await APIFetcher.shared.fetch(of: requestAPI)
             return response.toModel()
         },


### PR DESCRIPTION
## 연관된 이슈
#195 

## 작업 요약
타 유저 프로필 조회 api

## 작업 내용
- 핍 상세 리스트 뷰 -> 프로필 전환 
- 타 유저 프로필 조회 api 연결

## 스크린샷

<img src = "https://github.com/user-attachments/assets/39ddc661-fd47-49ff-b5aa-f99c8f145be6" width = 40%>